### PR TITLE
Fix: Actually rtrim() JSON in FinalNewLineNormalizer

### DIFF
--- a/src/FinalNewLineNormalizer.php
+++ b/src/FinalNewLineNormalizer.php
@@ -24,6 +24,6 @@ final class FinalNewLineNormalizer implements NormalizerInterface
             ));
         }
 
-        return $json . PHP_EOL;
+        return \rtrim($json) . PHP_EOL;
     }
 }

--- a/test/Unit/FinalNewLineNormalizerTest.php
+++ b/test/Unit/FinalNewLineNormalizerTest.php
@@ -56,7 +56,9 @@ final class FinalNewLineNormalizerTest extends Framework\TestCase
 }
 JSON;
 
-        $normalized = \rtrim($json . $whitespace) . PHP_EOL;
+        $json .= $whitespace;
+
+        $normalized = \rtrim($json) . PHP_EOL;
 
         $normalizer = new FinalNewLineNormalizer();
 


### PR DESCRIPTION
This PR

* [x] actually appends whitespace to `$json` before passing it to the `FinalNewLineNormalizer` in a test
* [ ] actually `rtrim()` `$json` before appending `PHP_EOL` in the `FinalNewLineNormalizer`

Follows #2.
