### PR TITLE
Fix: Add AutoFormatNormalizer to list of normalizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ $ composer require localheinz/json-normalizer
 
 This package comes with the following normalizers:
 
+* [`Localheinz\Json\Normalizer\AutoFormatNormalizer`](#autoformatnormalizer)
 * [`Localheinz\Json\Normalizer\CallableNormalizer`](#callablenormalizer)
 * [`Localheinz\Json\Normalizer\ChainNormalizer`](#chainnormalizer)
 * [`Localheinz\Json\Normalizer\FinalNewLineNormalizer`](#finalnewlinenormalizer)


### PR DESCRIPTION
This PR

* [x] adds the `AutoFormatNormalizer` to the list of normalizers

Follows #13.

💁‍♂️ Totally missed this yesterday.
