### PR TITLE
Fix: Set indent size for JSON files to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.json]
+indent_size = 4
+
 [*.md]
 trim_trailing_whitespace = false
 


### PR DESCRIPTION
This PR

* [x] sets the indent size for JSON files to 4
