### PR TITLE
Fix: Use corresponding parameter in exception message

### DIFF
--- a/src/Format/Format.php
+++ b/src/Format/Format.php
@@ -42,7 +42,7 @@ final class Format implements FormatInterface
         if (0 > $jsonEncodeOptions) {
             throw new \InvalidArgumentException(\sprintf(
                 '"%s" is not valid options for json_encode().',
-                $indent
+                $jsonEncodeOptions
             ));
         }
 

--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -36,7 +36,7 @@ final class FormatTest extends Framework\TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf(
             '"%s" is not valid options for json_encode().',
-            $indent
+            $jsonEncodeOptions
         ));
 
         new Format(


### PR DESCRIPTION
This PR

* [x] uses the corresponding parameter in an exception message