### PR TITLE
Fix: Rename FormatSniffer to Sniffer

### DIFF
--- a/src/AutoFormatNormalizer.php
+++ b/src/AutoFormatNormalizer.php
@@ -23,9 +23,9 @@ final class AutoFormatNormalizer implements NormalizerInterface
     private $normalizer;
 
     /**
-     * @var Format\FormatSnifferInterface
+     * @var Format\SnifferInterface
      */
-    private $formatSniffer;
+    private $sniffer;
 
     /**
      * @var Printer\PrinterInterface
@@ -34,11 +34,11 @@ final class AutoFormatNormalizer implements NormalizerInterface
 
     public function __construct(
         NormalizerInterface $normalizer,
-        Format\FormatSnifferInterface $formatSniffer = null,
+        Format\SnifferInterface $sniffer = null,
         Printer\PrinterInterface $printer = null
     ) {
         $this->normalizer = $normalizer;
-        $this->formatSniffer = $formatSniffer ?: new Format\FormatSniffer();
+        $this->sniffer = $sniffer ?: new Format\Sniffer();
         $this->printer = $printer ?: new Printer\Printer();
     }
 
@@ -51,7 +51,7 @@ final class AutoFormatNormalizer implements NormalizerInterface
             ));
         }
 
-        $format = $this->formatSniffer->sniff($json);
+        $format = $this->sniffer->sniff($json);
 
         $normalized = $this->normalizer->normalize($json);
 

--- a/src/Format/Sniffer.php
+++ b/src/Format/Sniffer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Format;
 
-final class FormatSniffer implements FormatSnifferInterface
+final class Sniffer implements SnifferInterface
 {
     public function sniff(string $json): FormatInterface
     {

--- a/src/Format/SnifferInterface.php
+++ b/src/Format/SnifferInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Format;
 
-interface FormatSnifferInterface
+interface SnifferInterface
 {
     /**
      * @param string $json

--- a/test/Unit/AutoFormatNormalizerTest.php
+++ b/test/Unit/AutoFormatNormalizerTest.php
@@ -84,9 +84,9 @@ JSON;
             ->shouldBeCalled()
             ->willReturn($hasFinalNewLine);
 
-        $formatSniffer = $this->prophesize(Format\FormatSnifferInterface::class);
+        $sniffer = $this->prophesize(Format\SnifferInterface::class);
 
-        $formatSniffer
+        $sniffer
             ->sniff(Argument::is($json))
             ->shouldBeCalled()
             ->willReturn($format);
@@ -103,7 +103,7 @@ JSON;
 
         $normalizer = new AutoFormatNormalizer(
             $composedNormalizer->reveal(),
-            $formatSniffer->reveal(),
+            $sniffer->reveal(),
             $printer->reveal()
         );
 

--- a/test/Unit/Format/SnifferTest.php
+++ b/test/Unit/Format/SnifferTest.php
@@ -14,25 +14,25 @@ declare(strict_types=1);
 namespace Localheinz\Json\Normalizer\Test\Unit\Format;
 
 use Localheinz\Json\Normalizer\Format\FormatInterface;
-use Localheinz\Json\Normalizer\Format\FormatSniffer;
-use Localheinz\Json\Normalizer\Format\FormatSnifferInterface;
+use Localheinz\Json\Normalizer\Format\Sniffer;
+use Localheinz\Json\Normalizer\Format\SnifferInterface;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
 
-final class FormatSnifferTest extends Framework\TestCase
+final class SnifferTest extends Framework\TestCase
 {
     use Helper;
 
     public function testImplementsSnifferInterface(): void
     {
-        $this->assertClassImplementsInterface(FormatSnifferInterface::class, FormatSniffer::class);
+        $this->assertClassImplementsInterface(SnifferInterface::class, Sniffer::class);
     }
 
     public function testSniffRejectsInvalidJson(): void
     {
         $json = $this->faker()->realText();
 
-        $sniffer = new FormatSniffer();
+        $sniffer = new Sniffer();
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf(
@@ -51,7 +51,7 @@ final class FormatSnifferTest extends Framework\TestCase
      */
     public function testSniffReturnsFormatWithJsonEncodeOptions(int $jsonEncodeOptions, string $json): void
     {
-        $sniffer = new FormatSniffer();
+        $sniffer = new Sniffer();
 
         $format = $sniffer->sniff($json);
 
@@ -100,7 +100,7 @@ final class FormatSnifferTest extends Framework\TestCase
      */
     public function testSniffReturnsFormatWithDefaultIndentIfUnableToSniff(string $json): void
     {
-        $sniffer = new FormatSniffer();
+        $sniffer = new Sniffer();
 
         $format = $sniffer->sniff($json);
 
@@ -141,7 +141,7 @@ ${indent}"bar",
 ]
 JSON;
 
-        $sniffer = new FormatSniffer();
+        $sniffer = new Sniffer();
 
         $format = $sniffer->sniff($json);
 
@@ -166,7 +166,7 @@ ${indent}"bar": 123,
 }
 JSON;
 
-        $sniffer = new FormatSniffer();
+        $sniffer = new Sniffer();
 
         $format = $sniffer->sniff($json);
 
@@ -212,7 +212,7 @@ JSON;
 JSON;
         $json .= $actualWhitespace;
 
-        $sniffer = new FormatSniffer();
+        $sniffer = new Sniffer();
 
         $format = $sniffer->sniff($json);
 
@@ -256,7 +256,7 @@ JSON;
 JSON;
         $json .= $actualWhitespace;
 
-        $sniffer = new FormatSniffer();
+        $sniffer = new Sniffer();
 
         $format = $sniffer->sniff($json);
 


### PR DESCRIPTION
This PR

* [x] renames `FormatSniffer` to `Sniffer`