### PR TITLE
Fix: Remove property definition that is never used

### DIFF
--- a/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasReference/schema.json
+++ b/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasReference/schema.json
@@ -4,9 +4,6 @@
         "name": {
             "type": "string"
         },
-        "description": {
-            "type": "string"
-        },
         "urls": {
             "$ref": "#/definitions/urls"
         }

--- a/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasType/IsArray/WithPropertyDefinitions/schema.json
+++ b/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasType/IsArray/WithPropertyDefinitions/schema.json
@@ -6,9 +6,6 @@
         "name": {
             "type": "string"
         },
-        "description": {
-            "type": "string"
-        },
         "urls": {
             "type": "array",
             "items": {

--- a/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasType/IsScalar/WithPropertyDefinitions/schema.json
+++ b/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasType/IsScalar/WithPropertyDefinitions/schema.json
@@ -4,9 +4,6 @@
         "name": {
             "type": "string"
         },
-        "description": {
-            "type": "string"
-        },
         "urls": {
             "type": "array",
             "items": {


### PR DESCRIPTION
This PR

* [x] removes a property definition that is never used