### PR TITLE
Fix: Consistently move additionalProperties after properties

### DIFF
--- a/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsArray/Schema/HasReference/schema.json
+++ b/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsArray/Schema/HasReference/schema.json
@@ -9,7 +9,6 @@
         },
         "url": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
                 "type": {
                     "type": "string"
@@ -17,7 +16,8 @@
                 "url": {
                     "type": "string"
                 }
-            }
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasReference/schema.json
+++ b/test/Fixture/SchemaNormalizer/NormalizeNormalizes/Data/IsObject/Schema/HasReference/schema.json
@@ -18,7 +18,6 @@
         },
         "url": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
                 "type": {
                     "type": "string"
@@ -26,7 +25,8 @@
                 "url": {
                     "type": "string"
                 }
-            }
+            },
+            "additionalProperties": false
         }
     }
 }


### PR DESCRIPTION
This PR

* [x] consistently moves `additionalProperties` after `properties` in schemas