### PR TITLE
Fix: Rename test method

### DIFF
--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -135,7 +135,7 @@ final class FormatTest extends Framework\TestCase
         $format->withJsonEncodeOptions($jsonEncodeOptions);
     }
 
-    public function testWithIndentClonesFormatAndSetsJsonEncodeOptions(): void
+    public function testWithJsonEncodeOptionsClonesFormatAndSetsJsonEncodeOptions(): void
     {
         $format = new Format(
             JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,


### PR DESCRIPTION
This PR

* [x] renames a test method

Follows #12.