### PR TITLE
Fix: Rename test method

### DIFF
--- a/test/Unit/Format/SnifferTest.php
+++ b/test/Unit/Format/SnifferTest.php
@@ -154,7 +154,7 @@ JSON;
      *
      * @param string $indent
      */
-    public function testSniffReturnsFormatWithIndentIndentSniffedFromObject(string $indent): void
+    public function testSniffReturnsFormatWithIndentSniffedFromObject(string $indent): void
     {
         $json = <<<JSON
 {


### PR DESCRIPTION
This PR

* [x] renames a test method

Follows #50.

🤦‍♂️