### PR TITLE
Enhancement: Sniff new-line character sequence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "^7.1",
     "justinrainbow/json-schema": "^4.0.0 || ^5.0.0",
-    "localheinz/json-printer": "^1.0.0"
+    "localheinz/json-printer": "^2.0.0"
   },
   "require-dev": {
     "infection/infection": "~0.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec1fccbe241dc60dca215392db4c4e4a",
+    "content-hash": "b23c8a997a4ba79e5851e89571f5e278",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -74,27 +74,27 @@
         },
         {
             "name": "localheinz/json-printer",
-            "version": "1.1.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/json-printer.git",
-                "reference": "49459a160c551b5504d1edcbb10692039071d08a"
+                "reference": "1a350fd94544df716d1c75ef107d34057f80ac7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/json-printer/zipball/49459a160c551b5504d1edcbb10692039071d08a",
-                "reference": "49459a160c551b5504d1edcbb10692039071d08a",
+                "url": "https://api.github.com/repos/localheinz/json-printer/zipball/1a350fd94544df716d1c75ef107d34057f80ac7a",
+                "reference": "1a350fd94544df716d1c75ef107d34057f80ac7a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0"
             },
             "require-dev": {
-                "infection/infection": "~0.7.0",
-                "localheinz/php-cs-fixer-config": "~1.9.0",
+                "infection/infection": "~0.8.1",
+                "localheinz/php-cs-fixer-config": "~1.13.1",
                 "localheinz/test-util": "0.6.1",
                 "phpbench/phpbench": "~0.14.0",
-                "phpunit/phpunit": "^6.5.5"
+                "phpunit/phpunit": "^6.5.7"
             },
             "type": "library",
             "autoload": {
@@ -119,7 +119,7 @@
                 "json",
                 "printer"
             ],
-            "time": "2018-01-27T21:05:05+00:00"
+            "time": "2018-04-06T22:10:47+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Format/Format.php
+++ b/src/Format/Format.php
@@ -21,6 +21,11 @@ final class Format implements FormatInterface
     private const PATTERN_INDENT = '/^[ \t]+$/';
 
     /**
+     * Constant for a regular expression matching valid new-line character sequence.
+     */
+    private const PATTERN_NEW_LINE = '/^(?>\r\n|\n|\r)$/';
+
+    /**
      * @var int
      */
     private $jsonEncodeOptions;
@@ -36,13 +41,19 @@ final class Format implements FormatInterface
     private $hasFinalNewLine;
 
     /**
+     * @var string
+     */
+    private $newLine;
+
+    /**
      * @param int    $jsonEncodeOptions
      * @param string $indent
+     * @param string $newLine
      * @param bool   $hasFinalNewLine
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(int $jsonEncodeOptions, string $indent, bool $hasFinalNewLine)
+    public function __construct(int $jsonEncodeOptions, string $indent, string $newLine, bool $hasFinalNewLine)
     {
         if (0 > $jsonEncodeOptions) {
             throw new \InvalidArgumentException(\sprintf(
@@ -58,8 +69,16 @@ final class Format implements FormatInterface
             ));
         }
 
+        if (1 !== \preg_match(self::PATTERN_NEW_LINE, $newLine)) {
+            throw new \InvalidArgumentException(\sprintf(
+                '"%s" is not a valid new-line character sequence.',
+                $newLine
+            ));
+        }
+
         $this->jsonEncodeOptions = $jsonEncodeOptions;
         $this->indent = $indent;
+        $this->newLine = $newLine;
         $this->hasFinalNewLine = $hasFinalNewLine;
     }
 
@@ -71,6 +90,11 @@ final class Format implements FormatInterface
     public function indent(): string
     {
         return $this->indent;
+    }
+
+    public function newLine(): string
+    {
+        return $this->newLine;
     }
 
     public function hasFinalNewLine(): bool
@@ -106,6 +130,22 @@ final class Format implements FormatInterface
         $mutated = clone $this;
 
         $mutated->indent = $indent;
+
+        return $mutated;
+    }
+
+    public function withNewLine(string $newLine): FormatInterface
+    {
+        if (1 !== \preg_match(self::PATTERN_NEW_LINE, $newLine)) {
+            throw new \InvalidArgumentException(\sprintf(
+                '"%s" is not a valid new-line character sequence.',
+                $newLine
+            ));
+        }
+
+        $mutated = clone $this;
+
+        $mutated->newLine = $newLine;
 
         return $mutated;
     }

--- a/src/Format/FormatInterface.php
+++ b/src/Format/FormatInterface.php
@@ -19,7 +19,18 @@ interface FormatInterface
 
     public function indent(): string;
 
+    public function newLine(): string;
+
     public function hasFinalNewLine(): bool;
+
+    /**
+     * @param int $jsonEncodeOptions
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return FormatInterface
+     */
+    public function withJsonEncodeOptions(int $jsonEncodeOptions): self;
 
     /**
      * @param string $indent
@@ -31,13 +42,13 @@ interface FormatInterface
     public function withIndent(string $indent): self;
 
     /**
-     * @param int $jsonEncodeOptions
+     * @param string $newLine
      *
      * @throws \InvalidArgumentException
      *
      * @return FormatInterface
      */
-    public function withJsonEncodeOptions(int $jsonEncodeOptions): self;
+    public function withNewLine(string $newLine): self;
 
     public function withHasFinalNewLine(bool $hasFinalNewLine): self;
 }

--- a/src/Format/Formatter.php
+++ b/src/Format/Formatter.php
@@ -45,13 +45,14 @@ final class Formatter implements FormatterInterface
 
         $printed = $this->printer->print(
             $encoded,
-            $format->indent()
+            $format->indent(),
+            $format->newLine()
         );
 
         if (!$format->hasFinalNewLine()) {
             return $printed;
         }
 
-        return $printed . PHP_EOL;
+        return $printed . $format->newLine();
     }
 }

--- a/src/Format/Sniffer.php
+++ b/src/Format/Sniffer.php
@@ -27,6 +27,7 @@ final class Sniffer implements SnifferInterface
         return new Format(
             $this->jsonEncodeOptions($json),
             $this->indent($json),
+            $this->newLine($json),
             $this->hasFinalNewLine($json)
         );
     }
@@ -53,6 +54,15 @@ final class Sniffer implements SnifferInterface
         }
 
         return '    ';
+    }
+
+    private function newLine(string $json): string
+    {
+        if (1 === \preg_match('/(?P<newLine>\r\n|\n|\r)/', $json, $match)) {
+            return $match['newLine'];
+        }
+
+        return PHP_EOL;
     }
 
     private function hasFinalNewLine(string $json): bool

--- a/test/Unit/Format/FormatterTest.php
+++ b/test/Unit/Format/FormatterTest.php
@@ -51,15 +51,19 @@ final class FormatterTest extends Framework\TestCase
     /**
      * @dataProvider providerFinalNewLine
      *
-     * @param bool   $hasFinalNewLine
-     * @param string $suffix
+     * @param bool $hasFinalNewLine
      */
-    public function testFormatEncodesWithJsonEncodeOptionsIndentsAndPossiblySuffixesWithFinalNewLine(bool $hasFinalNewLine, string $suffix): void
+    public function testFormatEncodesWithJsonEncodeOptionsIndentsAndPossiblySuffixesWithFinalNewLine(bool $hasFinalNewLine): void
     {
         $faker = $this->faker();
 
         $jsonEncodeOptions = $faker->numberBetween(1);
         $indent = \str_repeat(' ', $faker->numberBetween(1, 5));
+        $newLine = $faker->randomElement([
+            "\r\n",
+            "\n",
+            "\r",
+        ]);
 
         $json = <<<'JSON'
 {
@@ -93,6 +97,11 @@ JSON;
             ->willReturn($indent);
 
         $format
+            ->newLine()
+            ->shouldBeCalled()
+            ->willReturn($newLine);
+
+        $format
             ->hasFinalNewLine()
             ->shouldBeCalled()
             ->willReturn($hasFinalNewLine);
@@ -102,7 +111,8 @@ JSON;
         $printer
             ->print(
                 Argument::is($encoded),
-                Argument::is($indent)
+                Argument::is($indent),
+                Argument::is($newLine)
             )
             ->shouldBeCalled()
             ->willReturn($printed);
@@ -113,6 +123,8 @@ JSON;
             $json,
             $format->reveal()
         );
+
+        $suffix = $hasFinalNewLine ? $newLine : '';
 
         $this->assertSame($printed . $suffix, $formatted);
     }

--- a/test/Unit/Format/SnifferTest.php
+++ b/test/Unit/Format/SnifferTest.php
@@ -195,6 +195,74 @@ JSON;
     }
 
     /**
+     * @dataProvider providerJsonWithoutWhitespace
+     *
+     * @param string $json
+     */
+    public function testSniffReturnsFormatWithDefaultNewLineIfUnableToSniff(string $json): void
+    {
+        $sniffer = new Sniffer();
+
+        $format = $sniffer->sniff($json);
+
+        $this->assertInstanceOf(FormatInterface::class, $format);
+        $this->assertSame(PHP_EOL, $format->newLine());
+    }
+
+    /**
+     * @dataProvider providerNewLine
+     *
+     * @param string $newLine
+     */
+    public function testSniffReturnsFormatWithNewLineSniffedFromArray(string $newLine): void
+    {
+        $json = <<<JSON
+["foo",${newLine}"bar"]
+JSON;
+
+        $sniffer = new Sniffer();
+
+        $format = $sniffer->sniff($json);
+
+        $this->assertInstanceOf(FormatInterface::class, $format);
+        $this->assertSame($newLine, $format->newLine());
+    }
+
+    /**
+     * @dataProvider providerNewLine
+     *
+     * @param string $newLine
+     */
+    public function testSniffReturnsFormatWithNewLineNewLineSniffedFromObject(string $newLine): void
+    {
+        $json = <<<JSON
+{"foo": 9000,${newLine}"bar": 123}
+JSON;
+
+        $sniffer = new Sniffer();
+
+        $format = $sniffer->sniff($json);
+
+        $this->assertInstanceOf(FormatInterface::class, $format);
+        $this->assertSame($newLine, $format->newLine());
+    }
+
+    public function providerNewLine(): \Generator
+    {
+        $values = [
+            "\r\n",
+            "\n",
+            "\r",
+        ];
+
+        foreach ($values as $newLine) {
+            yield [
+                $newLine,
+            ];
+        }
+    }
+
+    /**
      * @dataProvider providerWhitespaceWithoutNewLine
      *
      * @param string $actualWhitespace


### PR DESCRIPTION
This PR

* [x] updates `localheinz/json-printer`
* [x] sniffs and prints using sniffed new-line character sequence

Related to https://github.com/localheinz/composer-normalize/issues/58.

💁‍♂️ For reference, see https://github.com/localheinz/json-printer/compare/1.1.0...2.0.0