### PR TITLE
Fix: Reject mixed tabs and spaces as indent

### DIFF
--- a/src/Format/Format.php
+++ b/src/Format/Format.php
@@ -18,7 +18,7 @@ final class Format implements FormatInterface
     /**
      * Constant for a regular expression matching valid indents.
      */
-    private const PATTERN_INDENT = '/^[ \t]+$/';
+    private const PATTERN_INDENT = '/^( +|\t+)$/';
 
     /**
      * Constant for a regular expression matching valid new-line character sequence.

--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -79,8 +79,9 @@ final class FormatTest extends Framework\TestCase
     public function providerInvalidIndent(): \Generator
     {
         $values = [
-            'not-whitespace' => $this->faker()->sentence,
-            'contains-line-feed' => " \n ",
+            'string-contains-line-feed' => " \n ",
+            'string-mixed-space-and-tab' => " \t",
+            'string-not-whitespace' => $this->faker()->sentence,
         ];
 
         foreach ($values as $key => $value) {


### PR DESCRIPTION
This PR

* [x] asserts that mixed space and tabs are rejected as indent values
* [x] adjusts a regular expression