### PR TITLE
Fix: Remove non-existent argument from DocBlock

### DIFF
--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -56,8 +56,7 @@ final class FormatTest extends Framework\TestCase
     /**
      * @dataProvider providerHasFinalNewLine
      *
-     * @param string $newLine
-     * @param bool   $hasFinalNewLine
+     * @param bool $hasFinalNewLine
      */
     public function testConstructorSetsValues(bool $hasFinalNewLine): void
     {


### PR DESCRIPTION
This PR

* [x] removes a non-existent argument from a DocBlock