### PR TITLE
Fix: Extend Throwable

### DIFF
--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Exception;
 
-interface ExceptionInterface
+interface ExceptionInterface extends \Throwable
 {
 }


### PR DESCRIPTION
This PR

* [x] Makes the Exception interface ~~implement~~ extend `\Throwable`