### PR TITLE
Fix: Rename InvalidJsonException to InvalidJsonEncodedException

### DIFF
--- a/src/Exception/InvalidJsonEncodedException.php
+++ b/src/Exception/InvalidJsonEncodedException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Exception;
 
-final class InvalidJsonException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidJsonEncodedException extends \InvalidArgumentException implements ExceptionInterface
 {
     /**
      * @var string

--- a/src/Json.php
+++ b/src/Json.php
@@ -44,7 +44,7 @@ final class Json implements JsonInterface
     /**
      * @param string $encoded
      *
-     * @throws Exception\InvalidJsonException
+     * @throws Exception\InvalidJsonEncodedException
      *
      * @return JsonInterface
      */
@@ -53,7 +53,7 @@ final class Json implements JsonInterface
         $decoded = \json_decode($encoded);
 
         if (null === $decoded && \JSON_ERROR_NONE !== \json_last_error()) {
-            throw Exception\InvalidJsonException::fromEncoded($encoded);
+            throw Exception\InvalidJsonEncodedException::fromEncoded($encoded);
         }
 
         return new self(

--- a/test/Unit/Exception/InvalidJsonEncodedExceptionTest.php
+++ b/test/Unit/Exception/InvalidJsonEncodedExceptionTest.php
@@ -13,25 +13,25 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidJsonException;
+use Localheinz\Json\Normalizer\Exception\InvalidJsonEncodedException;
 
 /**
  * @internal
  */
-final class InvalidJsonExceptionTest extends AbstractExceptionTestCase
+final class InvalidJsonEncodedExceptionTest extends AbstractExceptionTestCase
 {
     public function testExtendsInvalidArgumentException(): void
     {
-        $this->assertClassExtends(\InvalidArgumentException::class, InvalidJsonException::class);
+        $this->assertClassExtends(\InvalidArgumentException::class, InvalidJsonEncodedException::class);
     }
 
-    public function testFromEncodedReturnsInvalidJsonException(): void
+    public function testFromEncodedReturnsInvalidJsonEncodedException(): void
     {
         $encoded = $this->faker()->sentence;
 
-        $exception = InvalidJsonException::fromEncoded($encoded);
+        $exception = InvalidJsonEncodedException::fromEncoded($encoded);
 
-        $this->assertInstanceOf(InvalidJsonException::class, $exception);
+        $this->assertInstanceOf(InvalidJsonEncodedException::class, $exception);
 
         $message = \sprintf(
             '"%s" is not valid JSON.',

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -31,7 +31,7 @@ final class JsonTest extends Framework\TestCase
     {
         $string = $this->faker()->realText();
 
-        $this->expectException(Exception\InvalidJsonException::class);
+        $this->expectException(Exception\InvalidJsonEncodedException::class);
 
         Json::fromEncoded($string);
     }


### PR DESCRIPTION
This PR

* [x] renames `InvalidJsonException` to `InvalidJsonEncodedException`
