### PR TITLE
Enhancement: Turn method on Format into named constructor on JsonEncodeOptions

### DIFF
--- a/src/Format/Format.php
+++ b/src/Format/Format.php
@@ -54,7 +54,7 @@ final class Format
         $encoded = $json->encoded();
 
         return new self(
-            self::detectJsonEncodeOptions($encoded),
+            JsonEncodeOptions::fromJson($json),
             Indent::fromJson($json),
             self::detectNewLine($encoded),
             self::detectHasFinalNewLine($encoded)
@@ -115,21 +115,6 @@ final class Format
         $mutated->hasFinalNewLine = $hasFinalNewLine;
 
         return $mutated;
-    }
-
-    private static function detectJsonEncodeOptions(string $encoded): JsonEncodeOptions
-    {
-        $jsonEncodeOptions = 0;
-
-        if (false === \strpos($encoded, '\/')) {
-            $jsonEncodeOptions |= \JSON_UNESCAPED_SLASHES;
-        }
-
-        if (1 !== \preg_match('/(\\\\+)u([0-9a-f]{4})/i', $encoded)) {
-            $jsonEncodeOptions |= \JSON_UNESCAPED_UNICODE;
-        }
-
-        return JsonEncodeOptions::fromInt($jsonEncodeOptions);
     }
 
     private static function detectNewLine(string $encoded): NewLine

--- a/src/Format/JsonEncodeOptions.php
+++ b/src/Format/JsonEncodeOptions.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\Json\Normalizer\Format;
 
 use Localheinz\Json\Normalizer\Exception;
+use Localheinz\Json\Normalizer\Json;
 
 final class JsonEncodeOptions
 {
@@ -41,6 +42,21 @@ final class JsonEncodeOptions
         }
 
         return new self($value);
+    }
+
+    public static function fromJson(Json $json): self
+    {
+        $jsonEncodeOptions = 0;
+
+        if (false === \strpos($json->encoded(), '\/')) {
+            $jsonEncodeOptions |= \JSON_UNESCAPED_SLASHES;
+        }
+
+        if (1 !== \preg_match('/(\\\\+)u([0-9a-f]{4})/i', $json->encoded())) {
+            $jsonEncodeOptions |= \JSON_UNESCAPED_UNICODE;
+        }
+
+        return self::fromInt($jsonEncodeOptions);
     }
 
     public function value(): int

--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -139,56 +139,6 @@ final class FormatTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerJsonEncodeOptionsAndEncoded
-     *
-     * @param int    $jsonEncodeOptions
-     * @param string $encoded
-     */
-    public function testFromJsonReturnsFormatWithJsonEncodeOptions(int $jsonEncodeOptions, string $encoded): void
-    {
-        $json = Json::fromEncoded($encoded);
-
-        $format = Format::fromJson($json);
-
-        $this->assertInstanceOf(Format::class, $format);
-        $this->assertSame($jsonEncodeOptions, $format->jsonEncodeOptions()->value());
-    }
-
-    public function providerJsonEncodeOptionsAndEncoded(): array
-    {
-        return [
-            [
-                0,
-                '{
-  "name": "Andreas M\u00f6ller",
-  "url": "https:\/\/github.com\/localheinz\/json-normalizer"
-}',
-            ],
-            [
-                \JSON_UNESCAPED_SLASHES,
-                '{
-  "name": "Andreas M\u00f6ller",
-  "url": "https://github.com/localheinz/json-normalizer"
-}',
-            ],
-            [
-                \JSON_UNESCAPED_UNICODE,
-                '{
-  "name": "Andreas Möller",
-  "url": "https:\/\/github.com\/localheinz\/json-normalizer"
-}',
-            ],
-            [
-                \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
-                '{
-  "name": "Andreas Möller",
-  "url": "https://github.com/localheinz/json-normalizer"
-}',
-            ],
-        ];
-    }
-
-    /**
      * @dataProvider providerEncodedWithoutIndent
      *
      * @param string $encoded

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -15,6 +15,7 @@ namespace Localheinz\Json\Normalizer\Test\Unit\Format;
 
 use Localheinz\Json\Normalizer\Exception;
 use Localheinz\Json\Normalizer\Format\JsonEncodeOptions;
+use Localheinz\Json\Normalizer\Json;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
 
@@ -77,5 +78,55 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
                 $string,
             ];
         }
+    }
+
+    /**
+     * @dataProvider providerJsonEncodeOptionsAndEncoded
+     *
+     * @param int    $value
+     * @param string $encoded
+     */
+    public function testFromJsonReturnsJsonEncodeOptions(int $value, string $encoded): void
+    {
+        $json = Json::fromEncoded($encoded);
+
+        $jsonEncodeOptions = JsonEncodeOptions::fromJson($json);
+
+        $this->assertInstanceOf(JsonEncodeOptions::class, $jsonEncodeOptions);
+        $this->assertSame($value, $jsonEncodeOptions->value());
+    }
+
+    public function providerJsonEncodeOptionsAndEncoded(): array
+    {
+        return [
+            [
+                0,
+                '{
+  "name": "Andreas M\u00f6ller",
+  "url": "https:\/\/github.com\/localheinz\/json-normalizer"
+}',
+            ],
+            [
+                \JSON_UNESCAPED_SLASHES,
+                '{
+  "name": "Andreas M\u00f6ller",
+  "url": "https://github.com/localheinz/json-normalizer"
+}',
+            ],
+            [
+                \JSON_UNESCAPED_UNICODE,
+                '{
+  "name": "Andreas Möller",
+  "url": "https:\/\/github.com\/localheinz\/json-normalizer"
+}',
+            ],
+            [
+                \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+                '{
+  "name": "Andreas Möller",
+  "url": "https://github.com/localheinz/json-normalizer"
+}',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
This PR

* [x] turns a method on `Format` into a named constructor on `JsonEncodeOptions`

Follows #94.