### PR TITLE
Fix: Disallow installation of phpunit/phpunit:7.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "localheinz/test-util": "~0.7.0",
     "phpbench/phpbench": "~0.14.0",
     "phpstan/phpstan": "~0.10.3",
-    "phpunit/phpunit": "^7.4.0"
+    "phpunit/phpunit": "7.4.0"
   },
   "config": {
     "preferred-install": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6156a9b168eb05725be9e5721d233325",
+    "content-hash": "bf0c454da5758cee9ab8c57478061abb",
     "packages": [
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
This PR

* [x] disallows installation of `phpunit/phpunit:7.4.1`

Related to https://github.com/sebastianbergmann/phpunit/issues/3354.