### PR TITLE
Enhancement: Require localheinz/phpstan-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ For a full diff see [`0.9.0...master`](https://github.com/localheinz/json-normal
 ### Changed
 
 * Allowing injection of a `UriRetriever` into the `SchemaNormalizer`, and defaulting to a `ChainUriRetriever` which composes `FileGetContents` and `Curl` URI retrievers ([#104](https://github.com/localheinz/json-normalizer/pull/104)), by [@localheinz](https://github.com/localheinz)
-* Dropped `null` default values of constructor arguments of `AutoFormatNormalizer`, `FixedFormatNormalizer`, `Formatter`, `IndentNormalizer` to expose hard dependencies of `` (#109), by [@localheinz](https://github.com/localheinz)
+* Dropped `null` default values of constructor arguments of `AutoFormatNormalizer`, `FixedFormatNormalizer`, `Formatter`, `IndentNormalizer` to expose hard dependencies ([#109](https://github.com/localheinz/json-normalizer/pull/109)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.9.0`](https://github.com/localheinz/json-normalizer/releases/tag/0.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`0.9.0...master`](https://github.com/localheinz/json-normal
 ### Changed
 
 * Allowing injection of a `UriRetriever` into the `SchemaNormalizer`, and defaulting to a `ChainUriRetriever` which composes `FileGetContents` and `Curl` URI retrievers ([#104](https://github.com/localheinz/json-normalizer/pull/104)), by [@localheinz](https://github.com/localheinz)
+* Dropped `null` default values of constructor arguments of `AutoFormatNormalizer`, `FixedFormatNormalizer`, `Formatter`, `IndentNormalizer` to expose hard dependencies of `` (#109), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.9.0`](https://github.com/localheinz/json-normalizer/releases/tag/0.9.0)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ retain the original formatting, you can use the `AutoFormatNormalizer`.
 
 ```php
 use Localheinz\Json\Normalizer;
+use Localheinz\Json\Printer;
 
 $encoded = <<<'JSON'
 {
@@ -49,7 +50,10 @@ JSON;
 $json = Normalizer\Json::fromEncoded($encoded);
 
 /** @var Normalizer\NormalizerInterface $composedNormalizer*/
-$normalizer = new Normalizer\AutoFormatNormalizer($composedNormalizer);
+$normalizer = new Normalizer\AutoFormatNormalizer(
+    $composedNormalizer,
+    new Normalizer\Format\Formatter(new Printer\Printer())
+);
 
 $normalized = $normalizer->normalize($json);
 ```
@@ -114,6 +118,7 @@ If you want to apply multiple normalizers in a chain, you can use the `ChainNorm
 
 ```php
 use Localheinz\Json\Normalizer;
+use Localheinz\Json\Printer;
 
 $encoded = <<<'JSON'
 {
@@ -129,7 +134,10 @@ $jsonEncodeOptions = Normalizer\Format\JsonEncodeOptions::fromInt(JSON_UNESCAPED
 
 $normalizer = new Normalizer\ChainNormalizer(
     new Normalizer\JsonEncodeNormalizer($jsonEncodeOptions),
-    new Normalizer\IndentNormalizer($indent),
+    new Normalizer\IndentNormalizer(
+        $indent,
+        new Printer\Printer()
+    ),
     new Normalizer\FinalNewLineNormalizer()
 );
 
@@ -172,6 +180,7 @@ apply a fixed formatting, you can use the `FixedFormatNormalizer`.
 
 ```php
 use Localheinz\Json\Normalizer;
+use Localheinz\Json\Printer;
 
 $encoded = <<<'JSON'
 {
@@ -186,7 +195,8 @@ $json = Normalizer\Json::fromEncoded($encoded);
 /** @var Normalizer\Format\Format $format*/
 $normalizer = new Normalizer\FixedFormatNormalizer(
     $composedNormalizer, 
-    $format
+    $format,
+    new Normalizer\Format\Formatter(new Printer\Printer())
 );
 
 $normalized = $normalizer->normalize($json);
@@ -203,6 +213,7 @@ If you need to adjust the indentation of a JSON file, you can use the `IndentNor
 
 ```php
 use Localheinz\Json\Normalizer;
+use Localheinz\Json\Printer;
 
 $encoded = <<<'JSON'
 {
@@ -215,7 +226,10 @@ $json = Normalizer\Json::fromEncoded($encoded);
 
 $indent = Normalizer\Format\Indent::fromString('  ');
 
-$normalizer = new Normalizer\IndentNormalizer($indent);
+$normalizer = new Normalizer\IndentNormalizer(
+    $indent,
+    new Printer\Printer()
+);
 
 $normalized = $normalizer->normalize($json);
 ```
@@ -299,6 +313,8 @@ Let's assume the following schema
 exists at `/schema/example.json`.
 
 ```php
+use JsonSchema\SchemaStorage;
+use JsonSchema\Validator;
 use Localheinz\Json\Normalizer;
 
 $encoded = <<<'JSON'
@@ -310,7 +326,11 @@ JSON;
 
 $json = Normalizer\Json::fromEncoded($encoded);
 
-$normalizer = new Normalizer\SchemaNormalizer('file:///schema/example.json');
+$normalizer = new Normalizer\SchemaNormalizer(
+    'file:///schema/example.json',
+    new SchemaStorage(),
+    new Normalizer\Validator\SchemaValidator(new Validator())
+);
 
 $normalized = $normalizer->normalize($json);
 ```

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "infection/infection": "~0.11.2",
     "jangregor/phpstan-prophecy": "~0.2.0",
     "localheinz/php-cs-fixer-config": "~1.17.0",
+    "localheinz/phpstan-rules": "~0.5.0",
     "localheinz/test-util": "~0.7.0",
     "phpbench/phpbench": "~0.14.0",
     "phpstan/phpstan": "~0.10.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84595799dd3e3b3721550505f4a84d00",
+    "content-hash": "50152cfbf1dcb66f46c3c3efa07b2044",
     "packages": [
         {
             "name": "justinrainbow/json-schema",
@@ -950,6 +950,59 @@
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
             "time": "2018-11-27T07:03:30+00:00"
+        },
+        {
+            "name": "localheinz/phpstan-rules",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/phpstan-rules.git",
+                "reference": "f9bc5f56f3363b41b889dbc17e10d9f290439216"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/phpstan-rules/zipball/f9bc5f56f3363b41b889dbc17e10d9f290439216",
+                "reference": "f9bc5f56f3363b41b889dbc17e10d9f290439216",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.1.0",
+                "php": "^7.1",
+                "phpstan/phpstan": "~0.10.5"
+            },
+            "require-dev": {
+                "infection/infection": "~0.11.2",
+                "localheinz/composer-normalize": "^1.0.0",
+                "localheinz/php-cs-fixer-config": "~1.17.0",
+                "localheinz/test-util": "~0.7.0",
+                "phpstan/phpstan-deprecation-rules": "~0.10.2",
+                "phpstan/phpstan-strict-rules": "~0.10.1",
+                "phpunit/phpunit": "^7.4.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\PHPStan\\Rules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides additional rules for phpstan/phpstan.",
+            "homepage": "https://github.com/localheinz/phpstan-rules",
+            "keywords": [
+                "PHPStan",
+                "phpstan-extreme-rules",
+                "phpstan-rules"
+            ],
+            "time": "2018-12-05T20:37:27+00:00"
         },
         {
             "name": "localheinz/test-util",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon
+	- vendor/localheinz/phpstan-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ includes:
 parameters:
 	ignoreErrors:
 		- '#Method Localheinz\\Json\\Normalizer\\Json::__construct\(\) has parameter \$decoded with no typehint specified.#'
+		- '#Method Localheinz\\Json\\Normalizer\\JsonSchema\\Uri\\Retrievers\\ChainUriRetriever::getContentType\(\) has a nullable return type declaration.#'
 		- '#Method Localheinz\\Json\\Normalizer\\JsonSchema\\Uri\\Retrievers\\ChainUriRetriever::retrieve\(\) has no return typehint specified.#'
 		- '#Method Localheinz\\Json\\Normalizer\\JsonSchema\\Uri\\Retrievers\\ChainUriRetriever::retrieve\(\) has parameter \$uri with no typehint specified.#'
 		- '#Method Localheinz\\Json\\Normalizer\\SchemaNormalizer::resolveSchema\(\) has parameter \$data with no typehint specified.#'

--- a/src/AutoFormatNormalizer.php
+++ b/src/AutoFormatNormalizer.php
@@ -25,12 +25,10 @@ final class AutoFormatNormalizer implements NormalizerInterface
      */
     private $formatter;
 
-    public function __construct(
-        NormalizerInterface $normalizer,
-        Format\FormatterInterface $formatter = null
-    ) {
+    public function __construct(NormalizerInterface $normalizer, Format\FormatterInterface $formatter)
+    {
         $this->normalizer = $normalizer;
-        $this->formatter = $formatter ?: new Format\Formatter();
+        $this->formatter = $formatter;
     }
 
     public function normalize(Json $json): Json

--- a/src/FixedFormatNormalizer.php
+++ b/src/FixedFormatNormalizer.php
@@ -33,11 +33,11 @@ final class FixedFormatNormalizer implements NormalizerInterface
     public function __construct(
         NormalizerInterface $normalizer,
         Format\Format $format,
-        Format\FormatterInterface $formatter = null
+        Format\FormatterInterface $formatter
     ) {
         $this->normalizer = $normalizer;
         $this->format = $format;
-        $this->formatter = $formatter ?: new Format\Formatter();
+        $this->formatter = $formatter;
     }
 
     public function normalize(Json $json): Json

--- a/src/Format/Formatter.php
+++ b/src/Format/Formatter.php
@@ -23,9 +23,9 @@ final class Formatter implements FormatterInterface
      */
     private $printer;
 
-    public function __construct(Printer\PrinterInterface $printer = null)
+    public function __construct(Printer\PrinterInterface $printer)
     {
-        $this->printer = $printer ?: new Printer\Printer();
+        $this->printer = $printer;
     }
 
     public function format(Json $json, Format $format): Json

--- a/src/IndentNormalizer.php
+++ b/src/IndentNormalizer.php
@@ -27,10 +27,10 @@ final class IndentNormalizer implements NormalizerInterface
      */
     private $printer;
 
-    public function __construct(Format\Indent $indent, Printer\PrinterInterface $printer = null)
+    public function __construct(Format\Indent $indent, Printer\PrinterInterface $printer)
     {
         $this->indent = $indent;
-        $this->printer = $printer ?: new Printer\Printer();
+        $this->printer = $printer;
     }
 
     public function normalize(Json $json): Json

--- a/src/SchemaNormalizer.php
+++ b/src/SchemaNormalizer.php
@@ -13,14 +13,11 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer;
 
-use JsonSchema\Constraints;
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
 use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Exception\ResourceNotFoundException;
 use JsonSchema\Exception\UriResolverException;
 use JsonSchema\SchemaStorage;
-use JsonSchema\Uri\Retrievers;
-use JsonSchema\Uri\UriRetriever;
 
 final class SchemaNormalizer implements NormalizerInterface
 {
@@ -41,30 +38,9 @@ final class SchemaNormalizer implements NormalizerInterface
 
     public function __construct(
         string $schemaUri,
-        SchemaStorage $schemaStorage = null,
-        Validator\SchemaValidatorInterface $schemaValidator = null,
-        UriRetriever $uriRetriever = null
+        SchemaStorage $schemaStorage,
+        Validator\SchemaValidatorInterface $schemaValidator
     ) {
-        if (null === $uriRetriever) {
-            $uriRetriever = new UriRetriever();
-
-            $uriRetriever->setUriRetriever(new JsonSchema\Uri\Retrievers\ChainUriRetriever(
-                new Retrievers\FileGetContents(),
-                new Retrievers\Curl()
-            ));
-        }
-
-        if (null === $schemaStorage) {
-            $schemaStorage = new SchemaStorage($uriRetriever);
-        }
-
-        if (null === $schemaValidator) {
-            $schemaValidator = new Validator\SchemaValidator(new \JsonSchema\Validator(new Constraints\Factory(
-                $schemaStorage,
-                $uriRetriever
-            )));
-        }
-
         $this->schemaUri = $schemaUri;
         $this->schemaStorage = $schemaStorage;
         $this->schemaValidator = $schemaValidator;

--- a/test/Bench/SchemaNormalizerBench.php
+++ b/test/Bench/SchemaNormalizerBench.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Test\Bench;
 
+use JsonSchema\SchemaStorage;
+use JsonSchema\Validator;
 use Localheinz\Json\Normalizer\Json;
 use Localheinz\Json\Normalizer\SchemaNormalizer;
+use Localheinz\Json\Normalizer\Validator\SchemaValidator;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 
@@ -59,7 +62,11 @@ final class SchemaNormalizerBench
 
         $json = Json::fromEncoded($encoded);
 
-        $normalizer = new SchemaNormalizer($schemaUri);
+        $normalizer = new SchemaNormalizer(
+            $schemaUri,
+            new SchemaStorage(),
+            new SchemaValidator(new Validator())
+        );
 
         $normalizer->normalize($json);
     }

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -18,10 +18,12 @@ use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Exception\ResourceNotFoundException;
 use JsonSchema\Exception\UriResolverException;
 use JsonSchema\SchemaStorage;
+use JsonSchema\Validator;
 use Localheinz\Json\Normalizer\Exception;
 use Localheinz\Json\Normalizer\Json;
 use Localheinz\Json\Normalizer\SchemaNormalizer;
-use Localheinz\Json\Normalizer\Validator;
+use Localheinz\Json\Normalizer\Validator\SchemaValidator;
+use Localheinz\Json\Normalizer\Validator\SchemaValidatorInterface;
 use Prophecy\Argument;
 
 /**
@@ -52,7 +54,7 @@ JSON
         $normalizer = new SchemaNormalizer(
             $schemaUri,
             $schemaStorage->reveal(),
-            $this->prophesize(Validator\SchemaValidatorInterface::class)->reveal()
+            $this->prophesize(SchemaValidatorInterface::class)->reveal()
         );
 
         $this->expectException(Exception\SchemaUriCouldNotBeResolvedException::class);
@@ -83,7 +85,7 @@ JSON
         $normalizer = new SchemaNormalizer(
             $schemaUri,
             $schemaStorage->reveal(),
-            $this->prophesize(Validator\SchemaValidatorInterface::class)->reveal()
+            $this->prophesize(SchemaValidatorInterface::class)->reveal()
         );
 
         $this->expectException(Exception\SchemaUriCouldNotBeReadException::class);
@@ -114,7 +116,7 @@ JSON
         $normalizer = new SchemaNormalizer(
             $schemaUri,
             $schemaStorage->reveal(),
-            $this->prophesize(Validator\SchemaValidatorInterface::class)->reveal()
+            $this->prophesize(SchemaValidatorInterface::class)->reveal()
         );
 
         $this->expectException(Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException::class);
@@ -145,7 +147,7 @@ JSON
         $normalizer = new SchemaNormalizer(
             $schemaUri,
             $schemaStorage->reveal(),
-            $this->prophesize(Validator\SchemaValidatorInterface::class)->reveal()
+            $this->prophesize(SchemaValidatorInterface::class)->reveal()
         );
 
         $this->expectException(Exception\SchemaUriReferencesInvalidJsonDocumentException::class);
@@ -181,7 +183,7 @@ JSON;
             ->shouldBeCalled()
             ->willReturn($schemaDecoded);
 
-        $schemaValidator = $this->prophesize(Validator\SchemaValidatorInterface::class);
+        $schemaValidator = $this->prophesize(SchemaValidatorInterface::class);
 
         $schemaValidator
             ->isValid(
@@ -248,7 +250,7 @@ JSON
             ->shouldBeCalled()
             ->willReturn($schemaDecoded);
 
-        $schemaValidator = $this->prophesize(Validator\SchemaValidatorInterface::class);
+        $schemaValidator = $this->prophesize(SchemaValidatorInterface::class);
 
         $schemaValidator
             ->isValid(
@@ -290,7 +292,11 @@ JSON
     {
         $json = Json::fromEncoded($encoded);
 
-        $normalizer = new SchemaNormalizer($schemaUri);
+        $normalizer = new SchemaNormalizer(
+            $schemaUri,
+            new SchemaStorage(),
+            new SchemaValidator(new Validator())
+        );
 
         $normalized = $normalizer->normalize($json);
 


### PR DESCRIPTION
This PR

* [x] requires `localheinz/phpstan-rules`
* [x] includes `rules.neon` from `localheinz/phpstan-rules`
* [x] fixes issues detected via static analysis
* [x] ignores an error related to an interface we don't control