### PR TITLE
Enhancement: Add PHP 7.3 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ jobs:
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
+        - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer remove --dev localheinz/php-cs-fixer-config; fi
         - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
         - if [[ "$WITH_LOCKED" == "true" ]]; then composer install; fi
         - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,24 @@ jobs:
 
       env: WITH_HIGHEST=true
 
+    - <<: *TEST
+
+      php: 7.3
+
+      env: WITH_LOWEST=true
+
+    - <<: *TEST
+
+      php: 7.3
+
+      env: WITH_LOCKED=true
+
+    - <<: *TEST
+
+      php: 7.3
+
+      env: WITH_HIGHEST=true
+
     - stage: Infection
 
       php: 7.2


### PR DESCRIPTION
This PR

* [x] adds PHP 7.3 to the Travis CI build matrix
* [x] removes `localheinz/php-cs-fixer-config` on PHP 7.3