### PR TITLE
Fix: Always explicitly use Prophecy\Argument in expectations

### DIFF
--- a/test/Unit/ChainNormalizerTest.php
+++ b/test/Unit/ChainNormalizerTest.php
@@ -16,6 +16,7 @@ namespace Localheinz\Json\Normalizer\Test\Unit;
 use Localheinz\Json\Normalizer\ChainNormalizer;
 use Localheinz\Json\Normalizer\Json;
 use Localheinz\Json\Normalizer\NormalizerInterface;
+use Prophecy\Argument;
 
 /**
  * @internal
@@ -54,7 +55,7 @@ JSON
             $normalizer = $this->prophesize(NormalizerInterface::class);
 
             $normalizer
-                ->normalize($previous)
+                ->normalize(Argument::is($previous))
                 ->shouldBeCalled()
                 ->willReturn($result);
 


### PR DESCRIPTION
This PR

* [x] always explicitly uses `Prophecy\Argument` in expectations