### PR TITLE
Fix: Default to empty string as content type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`0.9.0...master`](https://github.com/localheinz/json-normal
 
 * Allowing injection of a `UriRetriever` into the `SchemaNormalizer`, and defaulting to a `ChainUriRetriever` which composes `FileGetContents` and `Curl` URI retrievers ([#104](https://github.com/localheinz/json-normalizer/pull/104)), by [@localheinz](https://github.com/localheinz)
 * Dropped `null` default values of constructor arguments of `AutoFormatNormalizer`, `FixedFormatNormalizer`, `Formatter`, `IndentNormalizer` to expose hard dependencies ([#109](https://github.com/localheinz/json-normalizer/pull/109)), by [@localheinz](https://github.com/localheinz)
+* Dropped nullable return type declaration from `ChainUriRetriever::getContentType()`, defaulting to an empty `string` when `ChainUriRetriever::retrieve()` wasn't invoked yet ([#132](https://github.com/localheinz/json-normalizer/pull/132)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.9.0`](https://github.com/localheinz/json-normalizer/releases/tag/0.9.0)
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,9 +13,7 @@ parameters:
 		- RuntimeException
 	ignoreErrors:
 		- '#Method Localheinz\\Json\\Normalizer\\Json::__construct\(\) has parameter \$decoded with no typehint specified.#'
-		- '#Method Localheinz\\Json\\Normalizer\\JsonSchema\\Uri\\Retrievers\\ChainUriRetriever::getContentType\(\) has a nullable return type declaration.#'
 		- '#Method Localheinz\\Json\\Normalizer\\SchemaNormalizer::resolveSchema\(\) has parameter \$data with no typehint specified.#'
-		- '#Return type \(string\|null\) of method Localheinz\\Json\\Normalizer\\JsonSchema\\Uri\\Retrievers\\ChainUriRetriever::getContentType\(\) should be covariant with return type \(string\) of method JsonSchema\\Uri\\Retrievers\\UriRetrieverInterface::getContentType\(\)#'
 	paths:
 		- src
 		- test

--- a/src/JsonSchema/Uri/Retrievers/ChainUriRetriever.php
+++ b/src/JsonSchema/Uri/Retrievers/ChainUriRetriever.php
@@ -25,9 +25,9 @@ final class ChainUriRetriever implements Uri\Retrievers\UriRetrieverInterface
     private $retrievers;
 
     /**
-     * @var null|string
+     * @var string
      */
-    private $contentType;
+    private $contentType = '';
 
     /**
      * @param Uri\Retrievers\UriRetrieverInterface ...$retrievers
@@ -63,7 +63,7 @@ final class ChainUriRetriever implements Uri\Retrievers\UriRetrieverInterface
         ));
     }
 
-    public function getContentType(): ?string
+    public function getContentType(): string
     {
         return $this->contentType;
     }

--- a/test/Unit/JsonSchema/Uri/Retrievers/ChainUriRetrieverTest.php
+++ b/test/Unit/JsonSchema/Uri/Retrievers/ChainUriRetrieverTest.php
@@ -46,7 +46,7 @@ final class ChainUriRetrieverTest extends Framework\TestCase
 
         $uriRetriever = new ChainUriRetriever($retriever);
 
-        self::assertNull($uriRetriever->getContentType());
+        self::assertSame('', $uriRetriever->getContentType());
     }
 
     public function testRetrieveThrowsResourceNotFoundExceptionWhenNoneOfTheRetrieversWhereAbleToRetrieveUri(): void


### PR DESCRIPTION
This PR

* [x] defaults to an empty string as content type when `ChainUriRetriever::retrieve()` wasn't invoked yet, dropping the nullable return type declaration