### PR TITLE
Enhancement: Use ergebnis/json-printer instead of localheinz/json-printer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`0.9.0...master`][0.9.0...master].
 * Allowing injection of a `UriRetriever` into the `SchemaNormalizer`, and defaulting to a `ChainUriRetriever` which composes `FileGetContents` and `Curl` URI retrievers ([#104]), by [@localheinz]
 * Dropped `null` default values of constructor arguments of `AutoFormatNormalizer`, `FixedFormatNormalizer`, `Formatter`, `IndentNormalizer` to expose hard dependencies ([#109]), by [@localheinz]
 * Dropped nullable return type declaration from `ChainUriRetriever::getContentType()`, defaulting to an empty `string` when `ChainUriRetriever::retrieve()` wasn't invoked yet ([#132]), by [@localheinz]
+* Started using `ergebnis/json-printer` instead of `localheinz/json-printer` ([#176]), by [@localheinz]
 
 ### Fixed
 
@@ -241,6 +242,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#109]: https://github.com/localheinz/json-normalizer/pull/109
 [#132]: https://github.com/localheinz/json-normalizer/pull/132
 [#163]: https://github.com/localheinz/json-normalizer/pull/163
+[#176]: https://github.com/localheinz/json-normalizer/pull/176
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
   "require": {
     "php": "^7.2",
     "ext-json": "*",
-    "justinrainbow/json-schema": "^4.0.0 || ^5.0.0",
-    "localheinz/json-printer": "^2.0.1"
+    "ergebnis/json-printer": "^3.0.1",
+    "justinrainbow/json-schema": "^4.0.0 || ^5.0.0"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,64 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b55a3be58f5a77bc8a186fbab9ee372a",
+    "content-hash": "b9dfe5d3b27dd104ba6909a8f25f0096",
     "packages": [
+        {
+            "name": "ergebnis/json-printer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-printer.git",
+                "reference": "182fe2f4223e40ba4f1ca2ccdb35e2dd8c1e0878"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-printer/zipball/182fe2f4223e40ba4f1ca2ccdb35e2dd8c1e0878",
+                "reference": "182fe2f4223e40ba4f1ca2ccdb35e2dd8c1e0878",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "ergebnis/phpstan-rules": "~0.14.0",
+                "ergebnis/test-util": "~0.9.0",
+                "infection/infection": "~0.13.6",
+                "phpbench/phpbench": "~0.16.10",
+                "phpstan/extension-installer": "^1.0.3",
+                "phpstan/phpstan": "~0.11.19",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Printer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a JSON printer, allowing for flexible indentation.",
+            "homepage": "https://github.com/ergebnis/json-printer",
+            "keywords": [
+                "formatter",
+                "json",
+                "printer"
+            ],
+            "time": "2019-12-15T09:53:05+00:00"
+        },
         {
             "name": "justinrainbow/json-schema",
             "version": "5.2.6",
@@ -71,56 +127,6 @@
                 "schema"
             ],
             "time": "2017-10-21T13:15:38+00:00"
-        },
-        {
-            "name": "localheinz/json-printer",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/json-printer.git",
-                "reference": "86f942599c8f9f922de4e21c2b9b6564c895cb0c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/json-printer/zipball/86f942599c8f9f922de4e21c2b9b6564c895cb0c",
-                "reference": "86f942599c8f9f922de4e21c2b9b6564c895cb0c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "infection/infection": "~0.8.1",
-                "localheinz/php-cs-fixer-config": "~1.14.0",
-                "localheinz/test-util": "0.6.1",
-                "phpbench/phpbench": "~0.14.0",
-                "phpunit/phpunit": "^6.5.7"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\Json\\Printer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides a JSON printer, allowing for flexible indentation.",
-            "homepage": "https://github.com/localheinz/json-printer",
-            "keywords": [
-                "formatter",
-                "json",
-                "printer"
-            ],
-            "abandoned": "ergebnis/json-printer",
-            "time": "2018-08-11T23:54:50+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Format/Formatter.php
+++ b/src/Format/Formatter.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Format;
 
+use Ergebnis\Json\Printer;
 use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Printer;
 
 final class Formatter implements FormatterInterface
 {

--- a/src/IndentNormalizer.php
+++ b/src/IndentNormalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer;
 
-use Localheinz\Json\Printer;
+use Ergebnis\Json\Printer;
 
 final class IndentNormalizer implements NormalizerInterface
 {

--- a/test/Unit/Format/FormatterTest.php
+++ b/test/Unit/Format/FormatterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Test\Unit\Format;
 
+use Ergebnis\Json\Printer;
 use Ergebnis\Test\Util\Helper;
 use Localheinz\Json\Normalizer\Format\Format;
 use Localheinz\Json\Normalizer\Format\Formatter;
@@ -21,7 +22,6 @@ use Localheinz\Json\Normalizer\Format\Indent;
 use Localheinz\Json\Normalizer\Format\JsonEncodeOptions;
 use Localheinz\Json\Normalizer\Format\NewLine;
 use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Printer;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 

--- a/test/Unit/IndentNormalizerTest.php
+++ b/test/Unit/IndentNormalizerTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Localheinz\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Printer\PrinterInterface;
 use Localheinz\Json\Normalizer\Format\Indent;
 use Localheinz\Json\Normalizer\IndentNormalizer;
 use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Printer\PrinterInterface;
 use Prophecy\Argument;
 
 /**


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/json-printer` instead of `localheinz/json-printer`