### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2018 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/json-normalizer
+@see https://github.com/ergebnis/json-normalizer
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header), [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/localheinz/json-normalizer/compare/0.9.0...HEAD)
+## Unreleased
 
 For a full diff see [`0.9.0...master`][0.9.0...master].
 
@@ -19,6 +19,37 @@ For a full diff see [`0.9.0...master`][0.9.0...master].
 * Dropped `null` default values of constructor arguments of `AutoFormatNormalizer`, `FixedFormatNormalizer`, `Formatter`, `IndentNormalizer` to expose hard dependencies ([#109]), by [@localheinz]
 * Dropped nullable return type declaration from `ChainUriRetriever::getContentType()`, defaulting to an empty `string` when `ChainUriRetriever::retrieve()` wasn't invoked yet ([#132]), by [@localheinz]
 * Started using `ergebnis/json-printer` instead of `localheinz/json-printer` ([#176]), by [@localheinz]
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#181]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/json-normalizer
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/json-normalizer
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\Json\\Normalizer/Ergebnis\\Json\\Normalizer/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\Json\Normalizer` with `Ergebnis\Json\Normalizer`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -166,83 +197,85 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 * Added `AutoFormatNormalizer` ([#13]), by [@localheinz]
 * Added `SchemaNormalizer` ([#15]), by [@localheinz]
 
-[0.1.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.1.0
-[0.2.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.2.0
-[0.3.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.3.0
-[0.4.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.4.0
-[0.5.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.5.0
-[0.5.1]: https://github.com/localheinz/json-normalizer/releases/tag/0.5.1
-[0.5.2]: https://github.com/localheinz/json-normalizer/releases/tag/0.5.2
-[0.6.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.6.0
-[0.7.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.7.0
-[0.8.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.8.0
-[0.9.0]: https://github.com/localheinz/json-normalizer/releases/tag/0.9.0
+[0.1.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.1.0
+[0.2.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.2.0
+[0.3.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.3.0
+[0.4.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.4.0
+[0.5.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.5.0
+[0.5.1]: https://github.com/ergebnis/json-normalizer/releases/tag/0.5.1
+[0.5.2]: https://github.com/ergebnis/json-normalizer/releases/tag/0.5.2
+[0.6.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.6.0
+[0.7.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.7.0
+[0.8.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.8.0
+[0.9.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.9.0
 
-[5d8b3e2...0.1.0]: https://github.com/localheinz/json-normalizer/compare/5d8b3e2...0.1.0
+[5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 
-[0.1.0...0.2.0]: https://github.com/localheinz/json-normalizer/compare/0.1.0...0.2.0
-[0.2.0...0.3.0]: https://github.com/localheinz/json-normalizer/compare/0.2.0...0.3.0
-[0.3.0...0.4.0]: https://github.com/localheinz/json-normalizer/compare/0.3.0...0.4.0
-[0.4.0...0.5.0]: https://github.com/localheinz/json-normalizer/compare/0.4.0...0.5.0
-[0.5.0...0.5.1]: https://github.com/localheinz/json-normalizer/compare/0.5.0...0.5.1
-[0.5.1...0.5.2]: https://github.com/localheinz/json-normalizer/compare/0.5.1...0.5.2
-[0.5.2...0.6.0]: https://github.com/localheinz/json-normalizer/compare/0.5.2...0.6.0
-[0.6.0...0.7.0]: https://github.com/localheinz/json-normalizer/compare/0.6.0...0.7.0
-[0.7.0...0.8.0]: https://github.com/localheinz/json-normalizer/compare/0.7.0...0.8.0
-[0.8.0...0.9.0]: https://github.com/localheinz/json-normalizer/compare/0.8.0...0.9.0
-[0.9.0...master]: https://github.com/localheinz/json-normalizer/compare/0.9.0...master
+[0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
+[0.2.0...0.3.0]: https://github.com/ergebnis/json-normalizer/compare/0.2.0...0.3.0
+[0.3.0...0.4.0]: https://github.com/ergebnis/json-normalizer/compare/0.3.0...0.4.0
+[0.4.0...0.5.0]: https://github.com/ergebnis/json-normalizer/compare/0.4.0...0.5.0
+[0.5.0...0.5.1]: https://github.com/ergebnis/json-normalizer/compare/0.5.0...0.5.1
+[0.5.1...0.5.2]: https://github.com/ergebnis/json-normalizer/compare/0.5.1...0.5.2
+[0.5.2...0.6.0]: https://github.com/ergebnis/json-normalizer/compare/0.5.2...0.6.0
+[0.6.0...0.7.0]: https://github.com/ergebnis/json-normalizer/compare/0.6.0...0.7.0
+[0.7.0...0.8.0]: https://github.com/ergebnis/json-normalizer/compare/0.7.0...0.8.0
+[0.8.0...0.9.0]: https://github.com/ergebnis/json-normalizer/compare/0.8.0...0.9.0
+[0.9.0...master]: https://github.com/ergebnis/json-normalizer/compare/0.9.0...master
 
-[#1]: https://github.com/localheinz/json-normalizer/pull/1
-[#2]: https://github.com/localheinz/json-normalizer/pull/2
-[#3]: https://github.com/localheinz/json-normalizer/pull/3
-[#7]: https://github.com/localheinz/json-normalizer/pull/7
-[#8]: https://github.com/localheinz/json-normalizer/pull/8
-[#9]: https://github.com/localheinz/json-normalizer/pull/9
-[#10]: https://github.com/localheinz/json-normalizer/pull/10
-[#12]: https://github.com/localheinz/json-normalizer/pull/12
-[#13]: https://github.com/localheinz/json-normalizer/pull/13
-[#15]: https://github.com/localheinz/json-normalizer/pull/15
-[#17]: https://github.com/localheinz/json-normalizer/pull/17
-[#27]: https://github.com/localheinz/json-normalizer/pull/27
-[#29]: https://github.com/localheinz/json-normalizer/pull/29
-[#30]: https://github.com/localheinz/json-normalizer/pull/30
-[#31]: https://github.com/localheinz/json-normalizer/pull/31
-[#37]: https://github.com/localheinz/json-normalizer/pull/37
-[#40]: https://github.com/localheinz/json-normalizer/pull/40
-[#45]: https://github.com/localheinz/json-normalizer/pull/45
-[#47]: https://github.com/localheinz/json-normalizer/pull/47
-[#49]: https://github.com/localheinz/json-normalizer/pull/49
-[#55]: https://github.com/localheinz/json-normalizer/pull/55
-[#64]: https://github.com/localheinz/json-normalizer/pull/64
-[#67]: https://github.com/localheinz/json-normalizer/pull/67
-[#68]: https://github.com/localheinz/json-normalizer/pull/68
-[#69]: https://github.com/localheinz/json-normalizer/pull/69
-[#71]: https://github.com/localheinz/json-normalizer/pull/71
-[#72]: https://github.com/localheinz/json-normalizer/pull/72
-[#73]: https://github.com/localheinz/json-normalizer/pull/73
-[#76]: https://github.com/localheinz/json-normalizer/pull/76
-[#77]: https://github.com/localheinz/json-normalizer/pull/77
-[#79]: https://github.com/localheinz/json-normalizer/pull/79
-[#82]: https://github.com/localheinz/json-normalizer/pull/82
-[#84]: https://github.com/localheinz/json-normalizer/pull/84
-[#85]: https://github.com/localheinz/json-normalizer/pull/85
-[#86]: https://github.com/localheinz/json-normalizer/pull/86
-[#88]: https://github.com/localheinz/json-normalizer/pull/88
-[#89]: https://github.com/localheinz/json-normalizer/pull/89
-[#90]: https://github.com/localheinz/json-normalizer/pull/90
-[#91]: https://github.com/localheinz/json-normalizer/pull/91
-[#92]: https://github.com/localheinz/json-normalizer/pull/92
-[#93]: https://github.com/localheinz/json-normalizer/pull/93
-[#94]: https://github.com/localheinz/json-normalizer/pull/94
-[#95]: https://github.com/localheinz/json-normalizer/pull/95
-[#96]: https://github.com/localheinz/json-normalizer/pull/96
-[#102]: https://github.com/localheinz/json-normalizer/pull/102
-[#103]: https://github.com/localheinz/json-normalizer/pull/103
-[#104]: https://github.com/localheinz/json-normalizer/pull/104
-[#109]: https://github.com/localheinz/json-normalizer/pull/109
-[#132]: https://github.com/localheinz/json-normalizer/pull/132
-[#163]: https://github.com/localheinz/json-normalizer/pull/163
-[#176]: https://github.com/localheinz/json-normalizer/pull/176
+[#1]: https://github.com/ergebnis/json-normalizer/pull/1
+[#2]: https://github.com/ergebnis/json-normalizer/pull/2
+[#3]: https://github.com/ergebnis/json-normalizer/pull/3
+[#7]: https://github.com/ergebnis/json-normalizer/pull/7
+[#8]: https://github.com/ergebnis/json-normalizer/pull/8
+[#9]: https://github.com/ergebnis/json-normalizer/pull/9
+[#10]: https://github.com/ergebnis/json-normalizer/pull/10
+[#12]: https://github.com/ergebnis/json-normalizer/pull/12
+[#13]: https://github.com/ergebnis/json-normalizer/pull/13
+[#15]: https://github.com/ergebnis/json-normalizer/pull/15
+[#17]: https://github.com/ergebnis/json-normalizer/pull/17
+[#27]: https://github.com/ergebnis/json-normalizer/pull/27
+[#29]: https://github.com/ergebnis/json-normalizer/pull/29
+[#30]: https://github.com/ergebnis/json-normalizer/pull/30
+[#31]: https://github.com/ergebnis/json-normalizer/pull/31
+[#37]: https://github.com/ergebnis/json-normalizer/pull/37
+[#40]: https://github.com/ergebnis/json-normalizer/pull/40
+[#45]: https://github.com/ergebnis/json-normalizer/pull/45
+[#47]: https://github.com/ergebnis/json-normalizer/pull/47
+[#49]: https://github.com/ergebnis/json-normalizer/pull/49
+[#55]: https://github.com/ergebnis/json-normalizer/pull/55
+[#64]: https://github.com/ergebnis/json-normalizer/pull/64
+[#67]: https://github.com/ergebnis/json-normalizer/pull/67
+[#68]: https://github.com/ergebnis/json-normalizer/pull/68
+[#69]: https://github.com/ergebnis/json-normalizer/pull/69
+[#71]: https://github.com/ergebnis/json-normalizer/pull/71
+[#72]: https://github.com/ergebnis/json-normalizer/pull/72
+[#73]: https://github.com/ergebnis/json-normalizer/pull/73
+[#76]: https://github.com/ergebnis/json-normalizer/pull/76
+[#77]: https://github.com/ergebnis/json-normalizer/pull/77
+[#79]: https://github.com/ergebnis/json-normalizer/pull/79
+[#82]: https://github.com/ergebnis/json-normalizer/pull/82
+[#84]: https://github.com/ergebnis/json-normalizer/pull/84
+[#85]: https://github.com/ergebnis/json-normalizer/pull/85
+[#86]: https://github.com/ergebnis/json-normalizer/pull/86
+[#88]: https://github.com/ergebnis/json-normalizer/pull/88
+[#89]: https://github.com/ergebnis/json-normalizer/pull/89
+[#90]: https://github.com/ergebnis/json-normalizer/pull/90
+[#91]: https://github.com/ergebnis/json-normalizer/pull/91
+[#92]: https://github.com/ergebnis/json-normalizer/pull/92
+[#93]: https://github.com/ergebnis/json-normalizer/pull/93
+[#94]: https://github.com/ergebnis/json-normalizer/pull/94
+[#95]: https://github.com/ergebnis/json-normalizer/pull/95
+[#96]: https://github.com/ergebnis/json-normalizer/pull/96
+[#102]: https://github.com/ergebnis/json-normalizer/pull/102
+[#103]: https://github.com/ergebnis/json-normalizer/pull/103
+[#104]: https://github.com/ergebnis/json-normalizer/pull/104
+[#109]: https://github.com/ergebnis/json-normalizer/pull/109
+[#132]: https://github.com/ergebnis/json-normalizer/pull/132
+[#163]: https://github.com/ergebnis/json-normalizer/pull/163
+[#176]: https://github.com/ergebnis/json-normalizer/pull/176
+[#181]: https://github.com/ergebnis/json-normalizer/pull/181
 
 [@BackEndTea]: https://github.com/BackEndTea
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # json-normalizer
 
-[![Continuous Integration](https://github.com/localheinz/json-normalizer/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/json-normalizer/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/json-normalizer/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/json-normalizer)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/json-normalizer/v/stable)](https://packagist.org/packages/localheinz/json-normalizer)
-[![Total Downloads](https://poser.pugx.org/localheinz/json-normalizer/downloads)](https://packagist.org/packages/localheinz/json-normalizer)
+[![Continuous Integration](https://github.com/ergebnis/json-normalizer/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/json-normalizer/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/json-normalizer/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/json-normalizer)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/json-normalizer/v/stable)](https://packagist.org/packages/ergebnis/json-normalizer)
+[![Total Downloads](https://poser.pugx.org/ergebnis/json-normalizer/downloads)](https://packagist.org/packages/ergebnis/json-normalizer)
 
 Provides normalizers for normalizing JSON documents.
 
@@ -12,7 +12,7 @@ Provides normalizers for normalizing JSON documents.
 Run
 
 ```
-$ composer require localheinz/json-normalizer
+$ composer require ergebnis/json-normalizer
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-  "name": "localheinz/json-normalizer",
+  "name": "ergebnis/json-normalizer",
   "type": "library",
   "description": "Provides normalizers for normalizing JSON documents.",
   "keywords": [
     "json",
     "normalizer"
   ],
-  "homepage": "https://github.com/localheinz/json-normalizer",
+  "homepage": "https://github.com/ergebnis/json-normalizer",
   "license": "MIT",
   "authors": [
     {
@@ -39,16 +39,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Json\\Normalizer\\": "src/"
+      "Ergebnis\\Json\\Normalizer\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Json\\Normalizer\\Test\\": "test/"
+      "Ergebnis\\Json\\Normalizer\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/json-normalizer/issues",
-    "source": "https://github.com/localheinz/json-normalizer"
+    "issues": "https://github.com/ergebnis/json-normalizer/issues",
+    "source": "https://github.com/ergebnis/json-normalizer"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60f1ce843a608b014e76c92f9e11bf62",
+    "content-hash": "fa9be8e96218cf19e110b8db60d3cd53",
     "packages": [
         {
             "name": "ergebnis/json-printer",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,12 +3,12 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Localheinz\\\\Json\\\\Normalizer\\\\Json\\:\\:__construct\\(\\) has parameter \\$decoded with no typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\Json\\\\Normalizer\\\\Json\\:\\:__construct\\(\\) has parameter \\$decoded with no typehint specified\\.$#"
 			count: 1
 			path: src/Json.php
 
 		-
-			message: "#^Method Localheinz\\\\Json\\\\Normalizer\\\\SchemaNormalizer\\:\\:resolveSchema\\(\\) has parameter \\$data with no typehint specified\\.$#"
+			message: "#^Method Ergebnis\\\\Json\\\\Normalizer\\\\SchemaNormalizer\\:\\:resolveSchema\\(\\) has parameter \\$data with no typehint specified\\.$#"
 			count: 1
 			path: src/SchemaNormalizer.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,9 +4,9 @@ includes:
 parameters:
 	ergebnis:
 		classesAllowedToBeExtended:
+			- Ergebnis\Json\Normalizer\Test\Unit\AbstractNormalizerTestCase
+			- Ergebnis\Json\Normalizer\Test\Unit\Exception\AbstractExceptionTestCase
 			- InvalidArgumentException
-			- Localheinz\Json\Normalizer\Test\Unit\AbstractNormalizerTestCase
-			- Localheinz\Json\Normalizer\Test\Unit\Exception\AbstractExceptionTestCase
 			- RuntimeException
 	inferPrivatePropertyTypeFromConstructor: true
 	level: max

--- a/src/AutoFormatNormalizer.php
+++ b/src/AutoFormatNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class AutoFormatNormalizer implements NormalizerInterface
 {

--- a/src/CallableNormalizer.php
+++ b/src/CallableNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class CallableNormalizer implements NormalizerInterface
 {

--- a/src/ChainNormalizer.php
+++ b/src/ChainNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class ChainNormalizer implements NormalizerInterface
 {

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 interface ExceptionInterface extends \Throwable
 {

--- a/src/Exception/InvalidIndentSizeException.php
+++ b/src/Exception/InvalidIndentSizeException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class InvalidIndentSizeException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Exception/InvalidIndentStringException.php
+++ b/src/Exception/InvalidIndentStringException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class InvalidIndentStringException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Exception/InvalidIndentStyleException.php
+++ b/src/Exception/InvalidIndentStyleException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class InvalidIndentStyleException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Exception/InvalidJsonEncodeOptionsException.php
+++ b/src/Exception/InvalidJsonEncodeOptionsException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class InvalidJsonEncodeOptionsException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Exception/InvalidJsonEncodedException.php
+++ b/src/Exception/InvalidJsonEncodedException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class InvalidJsonEncodedException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Exception/InvalidNewLineStringException.php
+++ b/src/Exception/InvalidNewLineStringException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class InvalidNewLineStringException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Exception/NormalizedInvalidAccordingToSchemaException.php
+++ b/src/Exception/NormalizedInvalidAccordingToSchemaException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class NormalizedInvalidAccordingToSchemaException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/OriginalInvalidAccordingToSchemaException.php
+++ b/src/Exception/OriginalInvalidAccordingToSchemaException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class OriginalInvalidAccordingToSchemaException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/SchemaUriCouldNotBeReadException.php
+++ b/src/Exception/SchemaUriCouldNotBeReadException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class SchemaUriCouldNotBeReadException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/SchemaUriCouldNotBeResolvedException.php
+++ b/src/Exception/SchemaUriCouldNotBeResolvedException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class SchemaUriCouldNotBeResolvedException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeException.php
+++ b/src/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class SchemaUriReferencesDocumentWithInvalidMediaTypeException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/SchemaUriReferencesInvalidJsonDocumentException.php
+++ b/src/Exception/SchemaUriReferencesInvalidJsonDocumentException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class SchemaUriReferencesInvalidJsonDocumentException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/UriRetrieverRequiredException.php
+++ b/src/Exception/UriRetrieverRequiredException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Exception;
+namespace Ergebnis\Json\Normalizer\Exception;
 
 final class UriRetrieverRequiredException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/FinalNewLineNormalizer.php
+++ b/src/FinalNewLineNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class FinalNewLineNormalizer implements NormalizerInterface
 {

--- a/src/FixedFormatNormalizer.php
+++ b/src/FixedFormatNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class FixedFormatNormalizer implements NormalizerInterface
 {

--- a/src/Format/Format.php
+++ b/src/Format/Format.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Format;
+namespace Ergebnis\Json\Normalizer\Format;
 
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\Json;
 
 final class Format
 {

--- a/src/Format/Formatter.php
+++ b/src/Format/Formatter.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Format;
+namespace Ergebnis\Json\Normalizer\Format;
 
+use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Printer;
-use Localheinz\Json\Normalizer\Json;
 
 final class Formatter implements FormatterInterface
 {

--- a/src/Format/FormatterInterface.php
+++ b/src/Format/FormatterInterface.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Format;
+namespace Ergebnis\Json\Normalizer\Format;
 
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\Json;
 
 interface FormatterInterface
 {

--- a/src/Format/Indent.php
+++ b/src/Format/Indent.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Format;
+namespace Ergebnis\Json\Normalizer\Format;
 
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Json;
 
 final class Indent
 {

--- a/src/Format/JsonEncodeOptions.php
+++ b/src/Format/JsonEncodeOptions.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Format;
+namespace Ergebnis\Json\Normalizer\Format;
 
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Json;
 
 final class JsonEncodeOptions
 {

--- a/src/Format/NewLine.php
+++ b/src/Format/NewLine.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Format;
+namespace Ergebnis\Json\Normalizer\Format;
 
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Json;
 
 final class NewLine
 {

--- a/src/IndentNormalizer.php
+++ b/src/IndentNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 use Ergebnis\Json\Printer;
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class Json
 {

--- a/src/JsonEncodeNormalizer.php
+++ b/src/JsonEncodeNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class JsonEncodeNormalizer implements NormalizerInterface
 {

--- a/src/JsonSchema/Uri/Retrievers/ChainUriRetriever.php
+++ b/src/JsonSchema/Uri/Retrievers/ChainUriRetriever.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\JsonSchema\Uri\Retrievers;
+namespace Ergebnis\Json\Normalizer\JsonSchema\Uri\Retrievers;
 
+use Ergebnis\Json\Normalizer\Exception;
 use JsonSchema\Exception\ResourceNotFoundException;
 use JsonSchema\Uri;
-use Localheinz\Json\Normalizer\Exception;
 
 final class ChainUriRetriever implements Uri\Retrievers\UriRetrieverInterface
 {

--- a/src/NoFinalNewLineNormalizer.php
+++ b/src/NoFinalNewLineNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 final class NoFinalNewLineNormalizer implements NormalizerInterface
 {

--- a/src/NormalizerInterface.php
+++ b/src/NormalizerInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 interface NormalizerInterface
 {

--- a/src/SchemaNormalizer.php
+++ b/src/SchemaNormalizer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer;
+namespace Ergebnis\Json\Normalizer;
 
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
 use JsonSchema\Exception\JsonDecodingException;

--- a/src/Validator/SchemaValidator.php
+++ b/src/Validator/SchemaValidator.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Validator;
+namespace Ergebnis\Json\Normalizer\Validator;
 
 use JsonSchema\Validator;
 

--- a/src/Validator/SchemaValidatorInterface.php
+++ b/src/Validator/SchemaValidatorInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Validator;
+namespace Ergebnis\Json\Normalizer\Validator;
 
 interface SchemaValidatorInterface
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\AutoReview;
+namespace Ergebnis\Json\Normalizer\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Json\\Normalizer\\',
-            'Localheinz\\Json\\Normalizer\\Test\\Unit\\'
+            'Ergebnis\\Json\\Normalizer\\',
+            'Ergebnis\\Json\\Normalizer\\Test\\Unit\\'
         );
     }
 }

--- a/test/Bench/SchemaNormalizerBench.php
+++ b/test/Bench/SchemaNormalizerBench.php
@@ -8,16 +8,16 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Bench;
+namespace Ergebnis\Json\Normalizer\Test\Bench;
 
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\SchemaNormalizer;
+use Ergebnis\Json\Normalizer\Validator\SchemaValidator;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Validator;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\SchemaNormalizer;
-use Localheinz\Json\Normalizer\Validator\SchemaValidator;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 

--- a/test/Unit/AbstractNormalizerTestCase.php
+++ b/test/Unit/AbstractNormalizerTestCase.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Normalizer\NormalizerInterface;
 use PHPUnit\Framework;
 
 /**
@@ -35,8 +35,8 @@ abstract class AbstractNormalizerTestCase extends Framework\TestCase
             '/Test$/',
             '',
             \str_replace(
-                'Localheinz\\Json\\Normalizer\\Test\\Unit\\',
-                'Localheinz\\Json\\Normalizer\\',
+                'Ergebnis\\Json\\Normalizer\\Test\\Unit\\',
+                'Ergebnis\\Json\\Normalizer\\',
                 static::class
             )
         );

--- a/test/Unit/AutoFormatNormalizerTest.php
+++ b/test/Unit/AutoFormatNormalizerTest.php
@@ -8,27 +8,27 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
-use Localheinz\Json\Normalizer\AutoFormatNormalizer;
-use Localheinz\Json\Normalizer\Format;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\AutoFormatNormalizer;
+use Ergebnis\Json\Normalizer\Format;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\AutoFormatNormalizer
+ * @covers \Ergebnis\Json\Normalizer\AutoFormatNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Format\Format
- * @uses \Localheinz\Json\Normalizer\Format\Indent
- * @uses \Localheinz\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Localheinz\Json\Normalizer\Format\NewLine
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Format\Format
+ * @uses \Ergebnis\Json\Normalizer\Format\Indent
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
+ * @uses \Ergebnis\Json\Normalizer\Format\NewLine
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class AutoFormatNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/CallableNormalizerTest.php
+++ b/test/Unit/CallableNormalizerTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
-use Localheinz\Json\Normalizer\CallableNormalizer;
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\CallableNormalizer;
+use Ergebnis\Json\Normalizer\Json;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\CallableNormalizer
+ * @covers \Ergebnis\Json\Normalizer\CallableNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class CallableNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/ChainNormalizerTest.php
+++ b/test/Unit/ChainNormalizerTest.php
@@ -8,22 +8,22 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
-use Localheinz\Json\Normalizer\ChainNormalizer;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\ChainNormalizer;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\ChainNormalizer
+ * @covers \Ergebnis\Json\Normalizer\ChainNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class ChainNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/Exception/AbstractExceptionTestCase.php
+++ b/test/Unit/Exception/AbstractExceptionTestCase.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
+use Ergebnis\Json\Normalizer\Exception;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Normalizer\Exception;
 use PHPUnit\Framework;
 
 /**
@@ -35,8 +35,8 @@ abstract class AbstractExceptionTestCase extends Framework\TestCase
             '/Test$/',
             '',
             \str_replace(
-                'Localheinz\\Json\\Normalizer\\Test\\Unit\\Exception\\',
-                'Localheinz\\Json\\Normalizer\\Exception\\',
+                'Ergebnis\\Json\\Normalizer\\Test\\Unit\\Exception\\',
+                'Ergebnis\\Json\\Normalizer\\Exception\\',
                 static::class
             )
         );

--- a/test/Unit/Exception/InvalidIndentSizeExceptionTest.php
+++ b/test/Unit/Exception/InvalidIndentSizeExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidIndentSizeException;
+use Ergebnis\Json\Normalizer\Exception\InvalidIndentSizeException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\InvalidIndentSizeException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentSizeException
  */
 final class InvalidIndentSizeExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/InvalidIndentStringExceptionTest.php
+++ b/test/Unit/Exception/InvalidIndentStringExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidIndentStringException;
+use Ergebnis\Json\Normalizer\Exception\InvalidIndentStringException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\InvalidIndentStringException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentStringException
  */
 final class InvalidIndentStringExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/InvalidIndentStyleExceptionTest.php
+++ b/test/Unit/Exception/InvalidIndentStyleExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidIndentStyleException;
+use Ergebnis\Json\Normalizer\Exception\InvalidIndentStyleException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\InvalidIndentStyleException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentStyleException
  */
 final class InvalidIndentStyleExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/InvalidJsonEncodeOptionsExceptionTest.php
+++ b/test/Unit/Exception/InvalidJsonEncodeOptionsExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException;
+use Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException
  */
 final class InvalidJsonEncodeOptionsExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/InvalidJsonEncodedExceptionTest.php
+++ b/test/Unit/Exception/InvalidJsonEncodedExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidJsonEncodedException;
+use Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodedException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\InvalidJsonEncodedException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodedException
  */
 final class InvalidJsonEncodedExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/InvalidNewLineStringExceptionTest.php
+++ b/test/Unit/Exception/InvalidNewLineStringExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidNewLineStringException;
+use Ergebnis\Json\Normalizer\Exception\InvalidNewLineStringException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\InvalidNewLineStringException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidNewLineStringException
  */
 final class InvalidNewLineStringExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/NormalizedInvalidAccordingToSchemaExceptionTest.php
+++ b/test/Unit/Exception/NormalizedInvalidAccordingToSchemaExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException;
+use Ergebnis\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException
+ * @covers \Ergebnis\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException
  */
 final class NormalizedInvalidAccordingToSchemaExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/OriginalInvalidAccordingToSchemaExceptionTest.php
+++ b/test/Unit/Exception/OriginalInvalidAccordingToSchemaExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException;
+use Ergebnis\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException
+ * @covers \Ergebnis\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException
  */
 final class OriginalInvalidAccordingToSchemaExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/SchemaUriCouldNotBeReadExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriCouldNotBeReadExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException;
+use Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException
  */
 final class SchemaUriCouldNotBeReadExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/SchemaUriCouldNotBeResolvedExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriCouldNotBeResolvedExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException;
+use Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException
  */
 final class SchemaUriCouldNotBeResolvedExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException;
+use Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
  */
 final class SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/SchemaUriReferencesInvalidJsonDocumentExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriReferencesInvalidJsonDocumentExceptionTest.php
@@ -8,17 +8,17 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException;
+use Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException
  */
 final class SchemaUriReferencesInvalidJsonDocumentExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/Exception/UriRetrieverRequiredExceptionTest.php
+++ b/test/Unit/Exception/UriRetrieverRequiredExceptionTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Exception;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Exception;
 
-use Localheinz\Json\Normalizer\Exception\InvalidNewLineStringException;
-use Localheinz\Json\Normalizer\Exception\UriRetrieverRequiredException;
+use Ergebnis\Json\Normalizer\Exception\InvalidNewLineStringException;
+use Ergebnis\Json\Normalizer\Exception\UriRetrieverRequiredException;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Exception\UriRetrieverRequiredException
+ * @covers \Ergebnis\Json\Normalizer\Exception\UriRetrieverRequiredException
  */
 final class UriRetrieverRequiredExceptionTest extends AbstractExceptionTestCase
 {

--- a/test/Unit/FinalNewLineNormalizerTest.php
+++ b/test/Unit/FinalNewLineNormalizerTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
-use Localheinz\Json\Normalizer\FinalNewLineNormalizer;
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\FinalNewLineNormalizer;
+use Ergebnis\Json\Normalizer\Json;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\FinalNewLineNormalizer
+ * @covers \Ergebnis\Json\Normalizer\FinalNewLineNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class FinalNewLineNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/FixedFormatNormalizerTest.php
+++ b/test/Unit/FixedFormatNormalizerTest.php
@@ -8,27 +8,27 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
-use Localheinz\Json\Normalizer\FixedFormatNormalizer;
-use Localheinz\Json\Normalizer\Format;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\FixedFormatNormalizer;
+use Ergebnis\Json\Normalizer\Format;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NormalizerInterface;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\FixedFormatNormalizer
+ * @covers \Ergebnis\Json\Normalizer\FixedFormatNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Format\Format
- * @uses \Localheinz\Json\Normalizer\Format\Indent
- * @uses \Localheinz\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Localheinz\Json\Normalizer\Format\NewLine
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Format\Format
+ * @uses \Ergebnis\Json\Normalizer\Format\Indent
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
+ * @uses \Ergebnis\Json\Normalizer\Format\NewLine
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class FixedFormatNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -8,27 +8,27 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Format;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Format;
 
-use Localheinz\Json\Normalizer\Format\Format;
-use Localheinz\Json\Normalizer\Format\Indent;
-use Localheinz\Json\Normalizer\Format\JsonEncodeOptions;
-use Localheinz\Json\Normalizer\Format\NewLine;
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\Format\Format;
+use Ergebnis\Json\Normalizer\Format\Indent;
+use Ergebnis\Json\Normalizer\Format\JsonEncodeOptions;
+use Ergebnis\Json\Normalizer\Format\NewLine;
+use Ergebnis\Json\Normalizer\Json;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Format\Format
+ * @covers \Ergebnis\Json\Normalizer\Format\Format
  *
- * @uses \Localheinz\Json\Normalizer\Format\Indent
- * @uses \Localheinz\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Localheinz\Json\Normalizer\Format\NewLine
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Format\Indent
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
+ * @uses \Ergebnis\Json\Normalizer\Format\NewLine
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class FormatTest extends Framework\TestCase
 {

--- a/test/Unit/Format/FormatterTest.php
+++ b/test/Unit/Format/FormatterTest.php
@@ -8,33 +8,33 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Format;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Format;
 
+use Ergebnis\Json\Normalizer\Format\Format;
+use Ergebnis\Json\Normalizer\Format\Formatter;
+use Ergebnis\Json\Normalizer\Format\FormatterInterface;
+use Ergebnis\Json\Normalizer\Format\Indent;
+use Ergebnis\Json\Normalizer\Format\JsonEncodeOptions;
+use Ergebnis\Json\Normalizer\Format\NewLine;
+use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Printer;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Normalizer\Format\Format;
-use Localheinz\Json\Normalizer\Format\Formatter;
-use Localheinz\Json\Normalizer\Format\FormatterInterface;
-use Localheinz\Json\Normalizer\Format\Indent;
-use Localheinz\Json\Normalizer\Format\JsonEncodeOptions;
-use Localheinz\Json\Normalizer\Format\NewLine;
-use Localheinz\Json\Normalizer\Json;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Format\Formatter
+ * @covers \Ergebnis\Json\Normalizer\Format\Formatter
  *
- * @uses \Localheinz\Json\Normalizer\Format\Format
- * @uses \Localheinz\Json\Normalizer\Format\Indent
- * @uses \Localheinz\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Localheinz\Json\Normalizer\Format\NewLine
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Format\Format
+ * @uses \Ergebnis\Json\Normalizer\Format\Indent
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
+ * @uses \Ergebnis\Json\Normalizer\Format\NewLine
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class FormatterTest extends Framework\TestCase
 {

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -8,26 +8,26 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Format;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Format;
 
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Format\Indent;
+use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Format\Indent;
-use Localheinz\Json\Normalizer\Json;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Format\Indent
+ * @covers \Ergebnis\Json\Normalizer\Format\Indent
  *
- * @uses \Localheinz\Json\Normalizer\Exception\InvalidIndentSizeException
- * @uses \Localheinz\Json\Normalizer\Exception\InvalidIndentStringException
- * @uses \Localheinz\Json\Normalizer\Exception\InvalidIndentStyleException
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentSizeException
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentStringException
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentStyleException
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class IndentTest extends Framework\TestCase
 {

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -8,24 +8,24 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Format;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Format;
 
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Format\JsonEncodeOptions;
+use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Format\JsonEncodeOptions;
-use Localheinz\Json\Normalizer\Json;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Format\JsonEncodeOptions
+ * @covers \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  *
- * @uses \Localheinz\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class JsonEncodeOptionsTest extends Framework\TestCase
 {
@@ -115,7 +115,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
                 \JSON_UNESCAPED_SLASHES,
                 '{
   "name": "Andreas M\u00f6ller",
-  "url": "https://github.com/localheinz/json-normalizer"
+  "url": "https://github.com/ergebnis/json-normalizer"
 }',
             ],
             [
@@ -129,7 +129,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
                 \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
                 '{
   "name": "Andreas Möller",
-  "url": "https://github.com/localheinz/json-normalizer"
+  "url": "https://github.com/ergebnis/json-normalizer"
 }',
             ],
         ];

--- a/test/Unit/Format/NewLineTest.php
+++ b/test/Unit/Format/NewLineTest.php
@@ -8,23 +8,23 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Format;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Format;
 
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Format\NewLine;
-use Localheinz\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Format\NewLine;
+use Ergebnis\Json\Normalizer\Json;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Format\NewLine
+ * @covers \Ergebnis\Json\Normalizer\Format\NewLine
  *
- * @uses \Localheinz\Json\Normalizer\Exception\InvalidNewLineStringException
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidNewLineStringException
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class NewLineTest extends Framework\TestCase
 {

--- a/test/Unit/IndentNormalizerTest.php
+++ b/test/Unit/IndentNormalizerTest.php
@@ -8,24 +8,24 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Format\Indent;
+use Ergebnis\Json\Normalizer\IndentNormalizer;
+use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Printer\PrinterInterface;
-use Localheinz\Json\Normalizer\Format\Indent;
-use Localheinz\Json\Normalizer\IndentNormalizer;
-use Localheinz\Json\Normalizer\Json;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\IndentNormalizer
+ * @covers \Ergebnis\Json\Normalizer\IndentNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Format\Indent
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Format\Indent
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class IndentNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/JsonEncodeNormalizerTest.php
+++ b/test/Unit/JsonEncodeNormalizerTest.php
@@ -8,22 +8,22 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
-use Localheinz\Json\Normalizer\Format\JsonEncodeOptions;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\JsonEncodeNormalizer;
+use Ergebnis\Json\Normalizer\Format\JsonEncodeOptions;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\JsonEncodeNormalizer;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\JsonEncodeNormalizer
+ * @covers \Ergebnis\Json\Normalizer\JsonEncodeNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class JsonEncodeNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/JsonSchema/Uri/Retrievers/ChainUriRetrieverTest.php
+++ b/test/Unit/JsonSchema/Uri/Retrievers/ChainUriRetrieverTest.php
@@ -8,25 +8,25 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\JsonSchema\Uri\Retrievers;
+namespace Ergebnis\Json\Normalizer\Test\Unit\JsonSchema\Uri\Retrievers;
 
+use Ergebnis\Json\Normalizer\Exception\UriRetrieverRequiredException;
+use Ergebnis\Json\Normalizer\JsonSchema\Uri\Retrievers\ChainUriRetriever;
 use Ergebnis\Test\Util\Helper;
 use JsonSchema\Exception;
 use JsonSchema\Uri;
-use Localheinz\Json\Normalizer\Exception\UriRetrieverRequiredException;
-use Localheinz\Json\Normalizer\JsonSchema\Uri\Retrievers\ChainUriRetriever;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\JsonSchema\Uri\Retrievers\ChainUriRetriever
+ * @covers \Ergebnis\Json\Normalizer\JsonSchema\Uri\Retrievers\ChainUriRetriever
  *
- * @uses \Localheinz\Json\Normalizer\Exception\UriRetrieverRequiredException
+ * @uses \Ergebnis\Json\Normalizer\Exception\UriRetrieverRequiredException
  */
 final class ChainUriRetrieverTest extends Framework\TestCase
 {

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -8,27 +8,27 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Format\Format;
+use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Format\Format;
-use Localheinz\Json\Normalizer\Json;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Json
+ * @covers \Ergebnis\Json\Normalizer\Json
  *
- * @uses \Localheinz\Json\Normalizer\Exception\InvalidJsonEncodedException
- * @uses \Localheinz\Json\Normalizer\Format\Format
- * @uses \Localheinz\Json\Normalizer\Format\Indent
- * @uses \Localheinz\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Localheinz\Json\Normalizer\Format\NewLine
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodedException
+ * @uses \Ergebnis\Json\Normalizer\Format\Format
+ * @uses \Ergebnis\Json\Normalizer\Format\Indent
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
+ * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  */
 final class JsonTest extends Framework\TestCase
 {

--- a/test/Unit/NoFinalNewLineNormalizerTest.php
+++ b/test/Unit/NoFinalNewLineNormalizerTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\NoFinalNewLineNormalizer;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\NoFinalNewLineNormalizer;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\NoFinalNewLineNormalizer
+ * @covers \Ergebnis\Json\Normalizer\NoFinalNewLineNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class NoFinalNewLineNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -8,37 +8,37 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit;
+namespace Ergebnis\Json\Normalizer\Test\Unit;
 
+use Ergebnis\Json\Normalizer\Exception;
+use Ergebnis\Json\Normalizer\Json;
+use Ergebnis\Json\Normalizer\SchemaNormalizer;
+use Ergebnis\Json\Normalizer\Validator\SchemaValidator;
+use Ergebnis\Json\Normalizer\Validator\SchemaValidatorInterface;
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
 use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Exception\ResourceNotFoundException;
 use JsonSchema\Exception\UriResolverException;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Validator;
-use Localheinz\Json\Normalizer\Exception;
-use Localheinz\Json\Normalizer\Json;
-use Localheinz\Json\Normalizer\SchemaNormalizer;
-use Localheinz\Json\Normalizer\Validator\SchemaValidator;
-use Localheinz\Json\Normalizer\Validator\SchemaValidatorInterface;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\SchemaNormalizer
+ * @covers \Ergebnis\Json\Normalizer\SchemaNormalizer
  *
- * @uses \Localheinz\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException
- * @uses \Localheinz\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException
- * @uses \Localheinz\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException
- * @uses \Localheinz\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException
- * @uses \Localheinz\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
- * @uses \Localheinz\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException
- * @uses \Localheinz\Json\Normalizer\Json
- * @uses \Localheinz\Json\Normalizer\Validator\SchemaValidator
+ * @uses \Ergebnis\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException
+ * @uses \Ergebnis\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException
+ * @uses \Ergebnis\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\Validator\SchemaValidator
  */
 final class SchemaNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/Validator/SchemaValidatorTest.php
+++ b/test/Unit/Validator/SchemaValidatorTest.php
@@ -8,22 +8,22 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-normalizer
+ * @see https://github.com/ergebnis/json-normalizer
  */
 
-namespace Localheinz\Json\Normalizer\Test\Unit\Validator;
+namespace Ergebnis\Json\Normalizer\Test\Unit\Validator;
 
+use Ergebnis\Json\Normalizer\Validator\SchemaValidator;
+use Ergebnis\Json\Normalizer\Validator\SchemaValidatorInterface;
 use Ergebnis\Test\Util\Helper;
 use JsonSchema\Validator;
-use Localheinz\Json\Normalizer\Validator\SchemaValidator;
-use Localheinz\Json\Normalizer\Validator\SchemaValidatorInterface;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Normalizer\Validator\SchemaValidator
+ * @covers \Ergebnis\Json\Normalizer\Validator\SchemaValidator
  */
 final class SchemaValidatorTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the namespace `Localheinz\Json\Normalizer` to `Ergebnis\Json\Normalizer` after the move to @ergebnis