### PR TITLE
Fix: Methods can be static

### DIFF
--- a/src/SchemaNormalizer.php
+++ b/src/SchemaNormalizer.php
@@ -122,7 +122,7 @@ final class SchemaNormalizer implements NormalizerInterface
             $schema
         );
 
-        if (!$this->describesType('array', $schema)) {
+        if (!self::describesType('array', $schema)) {
             return $data;
         }
 
@@ -162,7 +162,7 @@ final class SchemaNormalizer implements NormalizerInterface
             $schema
         );
 
-        if (!$this->describesType('object', $schema)) {
+        if (!self::describesType('object', $schema)) {
             return $data;
         }
 
@@ -239,7 +239,7 @@ final class SchemaNormalizer implements NormalizerInterface
         return $schema;
     }
 
-    private function describesType(string $type, \stdClass $schema): bool
+    private static function describesType(string $type, \stdClass $schema): bool
     {
         if (!\property_exists($schema, 'type')) {
             return false;

--- a/src/Vendor/Composer/PackageHashNormalizer.php
+++ b/src/Vendor/Composer/PackageHashNormalizer.php
@@ -59,7 +59,7 @@ final class PackageHashNormalizer implements NormalizerInterface
                 continue;
             }
 
-            $decoded->{$name} = $this->sortPackages($packages);
+            $decoded->{$name} = self::sortPackages($packages);
         }
 
         /** @var string $encoded */
@@ -78,7 +78,7 @@ final class PackageHashNormalizer implements NormalizerInterface
      *
      * @return string[]
      */
-    private function sortPackages(array $packages): array
+    private static function sortPackages(array $packages): array
     {
         $prefix = static function (string $requirement): string {
             if (1 === \preg_match(self::PLATFORM_PACKAGE_REGEX, $requirement)) {

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -72,7 +72,7 @@ final class VersionConstraintNormalizer implements NormalizerInterface
             }
 
             $decoded->{$name} = \array_map(function (string $versionConstraint): string {
-                return $this->normalizeVersionConstraint($versionConstraint);
+                return self::normalizeVersionConstraint($versionConstraint);
             }, $packages);
         }
 
@@ -82,7 +82,7 @@ final class VersionConstraintNormalizer implements NormalizerInterface
         return Json::fromEncoded($encoded);
     }
 
-    private function normalizeVersionConstraint(string $versionConstraint): string
+    private static function normalizeVersionConstraint(string $versionConstraint): string
     {
         $normalized = $versionConstraint;
 

--- a/test/Bench/SchemaNormalizerBench.php
+++ b/test/Bench/SchemaNormalizerBench.php
@@ -29,9 +29,9 @@ final class SchemaNormalizerBench
      */
     public function benchNormalizeProjectComposerFile(): void
     {
-        $this->normalize(
+        self::normalize(
             __DIR__ . '/../../composer.json',
-            $this->localComposerSchema()
+            self::localComposerSchema()
         );
     }
 
@@ -43,13 +43,13 @@ final class SchemaNormalizerBench
      */
     public function benchNormalizeLargeComposerFile(): void
     {
-        $this->normalize(
+        self::normalize(
             __DIR__ . '/../Fixture/LargeComposerFile/composer.json',
-            $this->localComposerSchema()
+            self::localComposerSchema()
         );
     }
 
-    private function normalize(string $file, string $schemaUri): void
+    private static function normalize(string $file, string $schemaUri): void
     {
         $encoded = \file_get_contents($file);
 
@@ -71,7 +71,7 @@ final class SchemaNormalizerBench
         $normalizer->normalize($json);
     }
 
-    private function localComposerSchema(): string
+    private static function localComposerSchema(): string
     {
         return \sprintf(
             'file://%s',

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -108,8 +108,8 @@ final class IndentTest extends Framework\TestCase
      */
     public function providerSizeStyleAndIndentString(): \Generator
     {
-        foreach ($this->sizes() as $key => $size) {
-            foreach ($this->characters() as $style => $character) {
+        foreach (self::sizes() as $key => $size) {
+            foreach (self::characters() as $style => $character) {
                 $string = \str_repeat(
                     $character,
                     $size
@@ -171,8 +171,8 @@ final class IndentTest extends Framework\TestCase
      */
     public function providerValidIndentString(): \Generator
     {
-        foreach ($this->sizes() as $key => $size) {
-            foreach ($this->characters() as $style => $character) {
+        foreach (self::sizes() as $key => $size) {
+            foreach (self::characters() as $style => $character) {
                 $string = \str_repeat(
                     $character,
                     $size
@@ -315,7 +315,7 @@ JSON
     /**
      * @return int[]
      */
-    private function sizes(): array
+    private static function sizes(): array
     {
         return [
             'int-one' => 1,
@@ -326,7 +326,7 @@ JSON
     /**
      * @return string[]
      */
-    private function characters(): array
+    private static function characters(): array
     {
         return [
             'space' => ' ',

--- a/test/Unit/JsonEncodeNormalizerTest.php
+++ b/test/Unit/JsonEncodeNormalizerTest.php
@@ -76,7 +76,7 @@ JSON
             \JSON_UNESCAPED_UNICODE,
         ];
 
-        $combinations = $this->combinations($jsonEncodeFlags);
+        $combinations = self::combinations($jsonEncodeFlags);
 
         foreach ($combinations as $combination) {
             $jsonEncodeOptions = \array_reduce(
@@ -102,7 +102,7 @@ JSON
      *
      * @return array<array<int>>
      */
-    private function combinations(array $elements): array
+    private static function combinations(array $elements): array
     {
         $combinations = [[]];
 

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -374,8 +374,8 @@ JSON
                 ));
             }
 
-            $expected = $this->jsonFromFile($normalizedFile);
-            $json = $this->jsonFromFile($jsonFile);
+            $expected = self::jsonFromFile($normalizedFile);
+            $json = self::jsonFromFile($jsonFile);
             $schemaUri = \sprintf(
                 'file://%s',
                 $schemaFile
@@ -394,7 +394,7 @@ JSON
         }
     }
 
-    private function jsonFromFile(string $file): string
+    private static function jsonFromFile(string $file): string
     {
         $json = \file_get_contents($file);
 

--- a/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
@@ -116,7 +116,7 @@ JSON
      */
     public function providerProperty(): \Generator
     {
-        foreach ($this->properties() as $value) {
+        foreach (self::properties() as $value) {
             yield $value => [
                 $value,
             ];
@@ -126,7 +126,7 @@ JSON
     /**
      * @return string[]
      */
-    private function properties(): array
+    private static function properties(): array
     {
         return [
             'config',

--- a/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
@@ -124,7 +124,7 @@ JSON
      */
     public function providerProperty(): \Generator
     {
-        foreach ($this->propertiesWhereKeysOfHashArePackages() as $value) {
+        foreach (self::propertiesWhereKeysOfHashArePackages() as $value) {
             yield $value => [
                 $value,
             ];
@@ -134,7 +134,7 @@ JSON
     /**
      * @return string[]
      */
-    private function propertiesWhereKeysOfHashArePackages(): array
+    private static function propertiesWhereKeysOfHashArePackages(): array
     {
         return [
             'conflict',

--- a/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
@@ -54,7 +54,7 @@ JSON
      */
     public function providerVersionConstraint(): \Generator
     {
-        foreach (\array_keys($this->versionConstraints()) as $versionConstraint) {
+        foreach (\array_keys(self::versionConstraints()) as $versionConstraint) {
             yield [
                 $versionConstraint,
             ];
@@ -88,7 +88,7 @@ JSON
      */
     public function providerProperty(): \Generator
     {
-        $properties = $this->propertiesWhereValuesOfHashAreVersionConstraints();
+        $properties = self::propertiesWhereValuesOfHashAreVersionConstraints();
 
         foreach ($properties as $property) {
             yield [
@@ -138,8 +138,8 @@ JSON
      */
     public function providerPropertyAndVersionConstraint(): \Generator
     {
-        $properties = $this->propertiesWhereValuesOfHashAreVersionConstraints();
-        $versionConstraints = $this->versionConstraints();
+        $properties = self::propertiesWhereValuesOfHashAreVersionConstraints();
+        $versionConstraints = self::versionConstraints();
 
         foreach ($properties as $property) {
             foreach ($versionConstraints as $versionConstraint => $normalizedVersionConstraint) {
@@ -198,8 +198,8 @@ JSON
             ' ',
         ];
 
-        $properties = $this->propertiesWhereValuesOfHashAreVersionConstraints();
-        $versionConstraints = \array_unique(\array_values($this->versionConstraints()));
+        $properties = self::propertiesWhereValuesOfHashAreVersionConstraints();
+        $versionConstraints = \array_unique(\array_values(self::versionConstraints()));
 
         foreach ($properties as $property) {
             foreach ($versionConstraints as $trimmedVersionConstraint) {
@@ -225,7 +225,7 @@ JSON
     /**
      * @return string[]
      */
-    private function propertiesWhereValuesOfHashAreVersionConstraints(): array
+    private static function propertiesWhereValuesOfHashAreVersionConstraints(): array
     {
         return [
             'conflict',
@@ -241,7 +241,7 @@ JSON
      *
      * @return string[]
      */
-    private function versionConstraints(): array
+    private static function versionConstraints(): array
     {
         return [
             /**


### PR DESCRIPTION
This PR

* [x] turns `private` instance methods into `static` methods where possible