### PR TITLE
FinalNewLineNormalizer should use NewLine from Json

### DIFF
--- a/src/FinalNewLineNormalizer.php
+++ b/src/FinalNewLineNormalizer.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
+use Ergebnis\Json\Normalizer\Format\NewLine;
+
 final class FinalNewLineNormalizer implements NormalizerInterface
 {
     public function normalize(Json $json): Json
     {
-        $withFinalNewLine = \rtrim($json->encoded()) . \PHP_EOL;
+        $newLine = NewLine::fromJson($json);
+        $withFinalNewLine = \rtrim($json->encoded()) . $newLine->__toString();
 
         return Json::fromEncoded($withFinalNewLine);
     }

--- a/test/Unit/FinalNewLineNormalizerTest.php
+++ b/test/Unit/FinalNewLineNormalizerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Test\Unit;
 
 use Ergebnis\Json\Normalizer\FinalNewLineNormalizer;
+use Ergebnis\Json\Normalizer\Format\NewLine;
 use Ergebnis\Json\Normalizer\Json;
 
 /**
@@ -45,7 +46,9 @@ JSON
 
         $normalized = $normalizer->normalize($json);
 
-        $expected = \rtrim($json->encoded()) . \PHP_EOL;
+        $newLine = NewLine::fromJson($json);
+
+        $expected = \rtrim($json->encoded()) . $newLine->__toString();
 
         self::assertSame($expected, $normalized->encoded());
     }


### PR DESCRIPTION
This PR want to change the FinalNewLineNormalizer, that the class uses the Newline from the Json input. This is needed to prevent using mixed Newline characters in the normalized Json. This could happen, if the Input Json uses Newlines different from PHP_EOL.