### PR TITLE
Enhancement: Implement validate() and return result with error messages

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,8 +9,8 @@ on: # yamllint disable-line rule:truthy
       - "master"
 
 env:
-  MIN_COVERED_MSI: 96
-  MIN_MSI: 96
+  MIN_COVERED_MSI: 91
+  MIN_MSI: 91
   REQUIRED_PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.11.0...master`][0.11.0...master].
 
+### Added
+
+* Added `SchemaValidator::validate()`, which returns a `Result` composing validation error messages ([#268]), by [@localheinz]
+
 ## [`0.11.0`][0.11.0]
 
 For a full diff see [`0.10.1...0.11.0`][0.10.1...0.11.0].
@@ -307,6 +311,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#191]: https://github.com/ergebnis/json-normalizer/pull/191
 [#202]: https://github.com/ergebnis/json-normalizer/pull/202
 [#203]: https://github.com/ergebnis/json-normalizer/pull/203
+[#268]: https://github.com/ergebnis/json-normalizer/pull/268
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@ergebnis]: https://github.com/ergebnis

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MIN_COVERED_MSI:=96
-MIN_MSI:=96
+MIN_COVERED_MSI:=91
+MIN_MSI:=91
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -176,11 +176,19 @@
     </MixedMethodCall>
   </file>
   <file src="test/Unit/Validator/SchemaValidatorTest.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument occurrences="6">
+      <code>$data</code>
+      <code>$schema</code>
+      <code>$data</code>
+      <code>$schema</code>
       <code>$data</code>
       <code>$schema</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment occurrences="6">
+      <code>$data</code>
+      <code>$schema</code>
+      <code>$data</code>
+      <code>$schema</code>
       <code>$data</code>
       <code>$schema</code>
     </MixedAssignment>

--- a/src/Exception/NormalizedInvalidAccordingToSchemaException.php
+++ b/src/Exception/NormalizedInvalidAccordingToSchemaException.php
@@ -20,7 +20,12 @@ final class NormalizedInvalidAccordingToSchemaException extends \RuntimeExceptio
      */
     private $schemaUri = '';
 
-    public static function fromSchemaUri(string $schemaUri): self
+    /**
+     * @var string[]
+     */
+    private $errors = [];
+
+    public static function fromSchemaUriAndErrors(string $schemaUri, string ...$errors): self
     {
         $exception = new self(\sprintf(
             'Normalized JSON is not valid according to schema "%s".',
@@ -28,6 +33,7 @@ final class NormalizedInvalidAccordingToSchemaException extends \RuntimeExceptio
         ));
 
         $exception->schemaUri = $schemaUri;
+        $exception->errors = $errors;
 
         return $exception;
     }
@@ -35,5 +41,13 @@ final class NormalizedInvalidAccordingToSchemaException extends \RuntimeExceptio
     public function schemaUri(): string
     {
         return $this->schemaUri;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function errors(): array
+    {
+        return $this->errors;
     }
 }

--- a/src/Exception/OriginalInvalidAccordingToSchemaException.php
+++ b/src/Exception/OriginalInvalidAccordingToSchemaException.php
@@ -20,7 +20,12 @@ final class OriginalInvalidAccordingToSchemaException extends \RuntimeException 
      */
     private $schemaUri = '';
 
-    public static function fromSchemaUri(string $schemaUri): self
+    /**
+     * @var string[]
+     */
+    private $errors = [];
+
+    public static function fromSchemaUriAndErrors(string $schemaUri, string ...$errors): self
     {
         $exception = new self(\sprintf(
             'Original JSON is not valid according to schema "%s".',
@@ -28,6 +33,7 @@ final class OriginalInvalidAccordingToSchemaException extends \RuntimeException 
         ));
 
         $exception->schemaUri = $schemaUri;
+        $exception->errors = $errors;
 
         return $exception;
     }
@@ -35,5 +41,13 @@ final class OriginalInvalidAccordingToSchemaException extends \RuntimeException 
     public function schemaUri(): string
     {
         return $this->schemaUri;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function errors(): array
+    {
+        return $this->errors;
     }
 }

--- a/src/Validator/Result.php
+++ b/src/Validator/Result.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/json-normalizer
+ */
+
+namespace Ergebnis\Json\Normalizer\Validator;
+
+final class Result
+{
+    /**
+     * @var string[]
+     */
+    private $errors;
+
+    private function __construct(string ...$errors)
+    {
+        $this->errors = $errors;
+    }
+
+    public static function create(string ...$errors): self
+    {
+        return new self(...$errors);
+    }
+
+    public function isValid(): bool
+    {
+        return [] === $this->errors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Validator/SchemaValidatorInterface.php
+++ b/src/Validator/SchemaValidatorInterface.php
@@ -22,4 +22,12 @@ interface SchemaValidatorInterface
      * @return bool
      */
     public function isValid($data, \stdClass $schema): bool;
+
+    /**
+     * @param null|array<mixed>|bool|float|int|\stdClass|string $data
+     * @param \stdClass                                         $schema
+     *
+     * @return Result
+     */
+    public function validate($data, \stdClass $schema): Result;
 }

--- a/test/Unit/Exception/NormalizedInvalidAccordingToSchemaExceptionTest.php
+++ b/test/Unit/Exception/NormalizedInvalidAccordingToSchemaExceptionTest.php
@@ -27,13 +27,25 @@ final class NormalizedInvalidAccordingToSchemaExceptionTest extends AbstractExce
         $exception = new NormalizedInvalidAccordingToSchemaException();
 
         self::assertSame('', $exception->schemaUri());
+        self::assertSame([], $exception->errors());
     }
 
     public function testFromSchemaUriReturnsNormalizedInvalidAccordingToSchemaException(): void
     {
-        $schemaUri = self::faker()->url;
+        $faker = self::faker();
 
-        $exception = NormalizedInvalidAccordingToSchemaException::fromSchemaUri($schemaUri);
+        $schemaUri = $faker->url;
+
+        $errors = [
+            $faker->sentence,
+            $faker->sentence,
+            $faker->sentence,
+        ];
+
+        $exception = NormalizedInvalidAccordingToSchemaException::fromSchemaUriAndErrors(
+            $schemaUri,
+            ...$errors
+        );
 
         $message = \sprintf(
             'Normalized JSON is not valid according to schema "%s".',
@@ -42,5 +54,6 @@ final class NormalizedInvalidAccordingToSchemaExceptionTest extends AbstractExce
 
         self::assertSame($message, $exception->getMessage());
         self::assertSame($schemaUri, $exception->schemaUri());
+        self::assertSame($errors, $exception->errors());
     }
 }

--- a/test/Unit/Exception/OriginalInvalidAccordingToSchemaExceptionTest.php
+++ b/test/Unit/Exception/OriginalInvalidAccordingToSchemaExceptionTest.php
@@ -26,14 +26,26 @@ final class OriginalInvalidAccordingToSchemaExceptionTest extends AbstractExcept
     {
         $exception = new OriginalInvalidAccordingToSchemaException();
 
+        self::assertSame([], $exception->errors());
         self::assertSame('', $exception->schemaUri());
     }
 
-    public function testFromSchemaUriReturnsOriginalInvalidAccordingToSchemaException(): void
+    public function testFromSchemaUriAndErrorsReturnsOriginalInvalidAccordingToSchemaException(): void
     {
-        $schemaUri = self::faker()->url;
+        $faker = self::faker();
 
-        $exception = OriginalInvalidAccordingToSchemaException::fromSchemaUri($schemaUri);
+        $schemaUri = $faker->url;
+
+        $errors = [
+            $faker->sentence,
+            $faker->sentence,
+            $faker->sentence,
+        ];
+
+        $exception = OriginalInvalidAccordingToSchemaException::fromSchemaUriAndErrors(
+            $schemaUri,
+            ...$errors
+        );
 
         $message = \sprintf(
             'Original JSON is not valid according to schema "%s".',
@@ -42,5 +54,6 @@ final class OriginalInvalidAccordingToSchemaExceptionTest extends AbstractExcept
 
         self::assertSame($message, $exception->getMessage());
         self::assertSame($schemaUri, $exception->schemaUri());
+        self::assertSame($errors, $exception->errors());
     }
 }

--- a/test/Unit/Validator/ResultTest.php
+++ b/test/Unit/Validator/ResultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/json-normalizer
+ */
+
+namespace Ergebnis\Json\Normalizer\Test\Unit\Validator;
+
+use Ergebnis\Json\Normalizer\Validator\Result;
+use Ergebnis\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @covers \Ergebnis\Json\Normalizer\Validator\Result
+ *
+ * @internal
+ */
+final class ResultTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testCreateReturnsResultWithoutErrors(): void
+    {
+        $result = Result::create();
+
+        self::assertTrue($result->isValid());
+        self::assertSame([], $result->errors());
+    }
+
+    public function testCreateReturnsResultWithErrors(): void
+    {
+        $faker = self::faker();
+
+        $errors = [
+            $faker->sentence,
+            $faker->sentence,
+            $faker->sentence,
+        ];
+
+        $result = Result::create(...$errors);
+
+        self::assertFalse($result->isValid());
+        self::assertSame($errors, $result->errors());
+    }
+}

--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -29,13 +29,14 @@ use Ergebnis\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer;
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\ComposerJsonNormalizer
  *
  * @uses \Ergebnis\Json\Normalizer\ChainNormalizer
+ * @uses \Ergebnis\Json\Normalizer\Json
+ * @uses \Ergebnis\Json\Normalizer\SchemaNormalizer
+ * @uses \Ergebnis\Json\Normalizer\Validator\Result
+ * @uses \Ergebnis\Json\Normalizer\Validator\SchemaValidator
  * @uses \Ergebnis\Json\Normalizer\Vendor\Composer\BinNormalizer
  * @uses \Ergebnis\Json\Normalizer\Vendor\Composer\ConfigHashNormalizer
  * @uses \Ergebnis\Json\Normalizer\Vendor\Composer\PackageHashNormalizer
  * @uses \Ergebnis\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer
- * @uses \Ergebnis\Json\Normalizer\Json
- * @uses \Ergebnis\Json\Normalizer\SchemaNormalizer
- * @uses \Ergebnis\Json\Normalizer\Validator\SchemaValidator
  */
 final class ComposerJsonNormalizerTest extends AbstractComposerTestCase
 {


### PR DESCRIPTION
This PR

* [x] implements `SchemaValidator::validate()` and returns `Result` with error messages