### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -83,7 +83,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":page_with_curl: Provides generic and vendor-specific normalizers for normalizing JSON documents."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.12.0...master`][0.12.0...master].
+For a full diff see [`0.12.0...main`][0.12.0...main].
 
 ## [`0.12.0`][0.12.0]
 
@@ -264,7 +264,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.10.0...0.10.1]: https://github.com/ergebnis/json-normalizer/compare/0.10.0...0.10.1
 [0.10.1...0.11.0]: https://github.com/ergebnis/json-normalizer/compare/0.10.1...0.11.0
 [0.11.0...0.12.0]: https://github.com/ergebnis/json-normalizer/compare/0.11.0...0.12.0
-[0.12.0...master]: https://github.com/ergebnis/json-normalizer/compare/0.12.0...master
+[0.12.0...main]: https://github.com/ergebnis/json-normalizer/compare/0.12.0...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # json-normalizer
 
-[![Integrate](https://github.com/ergebnis/json-normalizer/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/json-normalizer/actions)
-[![Prune](https://github.com/ergebnis/json-normalizer/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/json-normalizer/actions)
-[![Release](https://github.com/ergebnis/json-normalizer/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/json-normalizer/actions)
-[![Renew](https://github.com/ergebnis/json-normalizer/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/json-normalizer/actions)
+[![Integrate](https://github.com/ergebnis/json-normalizer/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/json-normalizer/actions)
+[![Prune](https://github.com/ergebnis/json-normalizer/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/json-normalizer/actions)
+[![Release](https://github.com/ergebnis/json-normalizer/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/json-normalizer/actions)
+[![Renew](https://github.com/ergebnis/json-normalizer/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/json-normalizer/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/json-normalizer/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/json-normalizer)
+[![Code Coverage](https://codecov.io/gh/ergebnis/json-normalizer/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/json-normalizer)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/json-normalizer/coverage.svg)](https://shepherd.dev/github/ergebnis/json-normalizer)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/json-normalizer/v/stable)](https://packagist.org/packages/ergebnis/json-normalizer)
@@ -437,7 +437,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 

--- a/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
@@ -247,9 +247,9 @@ JSON
             /**
              * @see https://getcomposer.org/doc/articles/versions.md#branches
              */
-            'dev-master' => 'dev-master',
+            'dev-main' => 'dev-main',
             'dev-my-feature' => 'dev-my-feature',
-            'dev-master#bf2eeff' => 'dev-master#bf2eeff',
+            'dev-main#bf2eeff' => 'dev-main#bf2eeff',
             /**
              * @see https://getcomposer.org/doc/articles/versions.md#exact-version-constraint
              */


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.