### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (7.4, locked)"
-          - "Coding Standards (7.1, locked)"
+          - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.1, highest)"
-          - "Tests (7.1, locked)"
-          - "Tests (7.1, lowest)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"
@@ -219,7 +219,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.13.0...main`][0.13.0...main].
+For a full diff see [`0.13.1...main`][0.13.1...main].
+
+## [`0.13.1`][0.13.1]
+
+For a full diff see [`0.13.0...0.13.1`][0.13.0...0.13.1].
+
+### Changed
+
+* Dropped support for PHP 7.1 ([#335]), by [@localheinz]
 
 ## [`0.13.0`][0.13.0]
 
@@ -257,6 +265,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.11.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.11.0
 [0.12.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.12.0
 [0.13.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.13.0
+[0.13.1]: https://github.com/ergebnis/json-normalizer/releases/tag/0.13.1
 
 [5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
@@ -274,7 +283,8 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.10.1...0.11.0]: https://github.com/ergebnis/json-normalizer/compare/0.10.1...0.11.0
 [0.11.0...0.12.0]: https://github.com/ergebnis/json-normalizer/compare/0.11.0...0.12.0
 [0.12.0...0.13.0]: https://github.com/ergebnis/json-normalizer/compare/0.12.0...0.13.0
-[0.13.0...main]: https://github.com/ergebnis/json-normalizer/compare/0.13.0...main
+[0.13.0...0.13.1]: https://github.com/ergebnis/json-normalizer/compare/0.13.0...0.13.1
+[0.13.1...main]: https://github.com/ergebnis/json-normalizer/compare/0.13.1...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2
@@ -334,6 +344,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#268]: https://github.com/ergebnis/json-normalizer/pull/268
 [#269]: https://github.com/ergebnis/json-normalizer/pull/269
 [#308]: https://github.com/ergebnis/json-normalizer/pull/308
+[#335]: https://github.com/ergebnis/json-normalizer/pull/335
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@ergebnis]: https://github.com/ergebnis

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ^8.0",
+    "php": "^7.2 || ^8.0",
     "ext-json": "*",
     "ergebnis/json-printer": "^3.1.0",
     "justinrainbow/json-schema": "^5.2.10"
@@ -38,7 +38,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.33"
+      "php": "7.2.33"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3558295a8a87ee19d0ef4e3a1e243510",
+    "content-hash": "175cfb7f95b35d46d0edc17970db7820",
     "packages": [
         {
             "name": "ergebnis/json-printer",
@@ -4893,12 +4893,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.2.33"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/ergebnis/composer-normalize/issues/529.