### PR TITLE
Fix: Handle more cases for hyphenated version ranges

### DIFF
--- a/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
@@ -258,6 +258,9 @@ JSON
              */
             '1.0 - 2.0' => '1.0 - 2.0',
             '1.0  -  2.0' => '1.0 - 2.0',
+            '1.0-2.0' => '1.0 - 2.0',
+            '1.0- 2.0' => '1.0 - 2.0',
+            '1.0 -2.0' => '1.0 - 2.0',
             /**
              * @see https://getcomposer.org/doc/articles/versions.md#next-significant-release-operators
              */


### PR DESCRIPTION
This PR

* [x] adds more test cases for hyphenated version ranges
* [ ] handles more cases for hyphenated version ranges