### PR TITLE
Enhancement: Extract constant for indent characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.13.1...main`][0.13.1...main].
+For a full diff see [`0.14.0...main`][0.14.0...main].
+
+## [`0.14.0`][0.14.0]
+
+For a full diff see [`0.13.1...0.14.0`][0.13.1...0.14.0].
+
+### Added
+
+* Extracted an `Indent::CHARACTERS` constant that exposes a map of indent styles to indent characters ([#383]), by [@localheinz]
 
 ## [`0.13.1`][0.13.1]
 
@@ -266,6 +274,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.12.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.12.0
 [0.13.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.13.0
 [0.13.1]: https://github.com/ergebnis/json-normalizer/releases/tag/0.13.1
+[0.14.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.14.0
 
 [5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
@@ -284,7 +293,8 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.11.0...0.12.0]: https://github.com/ergebnis/json-normalizer/compare/0.11.0...0.12.0
 [0.12.0...0.13.0]: https://github.com/ergebnis/json-normalizer/compare/0.12.0...0.13.0
 [0.13.0...0.13.1]: https://github.com/ergebnis/json-normalizer/compare/0.13.0...0.13.1
-[0.13.1...main]: https://github.com/ergebnis/json-normalizer/compare/0.13.1...main
+[0.13.1...0.14.0]: https://github.com/ergebnis/json-normalizer/compare/0.13.1...0.14.0
+[0.14.0...main]: https://github.com/ergebnis/json-normalizer/compare/0.14.0...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2
@@ -345,6 +355,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#269]: https://github.com/ergebnis/json-normalizer/pull/269
 [#308]: https://github.com/ergebnis/json-normalizer/pull/308
 [#335]: https://github.com/ergebnis/json-normalizer/pull/335
+[#383]: https://github.com/ergebnis/json-normalizer/pull/383
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@ergebnis]: https://github.com/ergebnis

--- a/src/Format/Indent.php
+++ b/src/Format/Indent.php
@@ -18,6 +18,11 @@ use Ergebnis\Json\Normalizer\Json;
 
 final class Indent
 {
+    public const CHARACTERS = [
+        'space' => ' ',
+        'tab' => "\t",
+    ];
+
     /**
      * @var string
      */
@@ -60,21 +65,15 @@ final class Indent
             );
         }
 
-        /** @var array<string, string> $characters */
-        $characters = [
-            'space' => ' ',
-            'tab' => "\t",
-        ];
-
-        if (!\array_key_exists($style, $characters)) {
+        if (!\array_key_exists($style, self::CHARACTERS)) {
             throw Exception\InvalidIndentStyleException::fromStyleAndAllowedStyles(
                 $style,
-                ...\array_keys($characters)
+                ...\array_keys(self::CHARACTERS)
             );
         }
 
         $value = \str_repeat(
-            $characters[$style],
+            self::CHARACTERS[$style],
             $size
         );
 

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -33,15 +33,22 @@ final class IndentTest extends Framework\TestCase
 {
     use Helper;
 
+    public function testConstants(): void
+    {
+        $characters = [
+            'space' => ' ',
+            'tab' => "\t",
+        ];
+
+        self::assertSame($characters, Indent::CHARACTERS);
+    }
+
     /**
      * @dataProvider providerInvalidSize
      */
     public function testFromSizeAndStyleRejectsInvalidSize(int $size): void
     {
-        $style = self::faker()->randomElement([
-            'space',
-            'tab',
-        ]);
+        $style = self::faker()->randomElement(\array_keys(Indent::CHARACTERS));
 
         $this->expectException(Exception\InvalidIndentSizeException::class);
 
@@ -103,7 +110,7 @@ final class IndentTest extends Framework\TestCase
     public function providerSizeStyleAndIndentString(): \Generator
     {
         foreach (self::sizes() as $key => $size) {
-            foreach (self::characters() as $style => $character) {
+            foreach (Indent::CHARACTERS as $style => $character) {
                 $string = \str_repeat(
                     $character,
                     $size
@@ -162,7 +169,7 @@ final class IndentTest extends Framework\TestCase
     public function providerValidIndentString(): \Generator
     {
         foreach (self::sizes() as $key => $size) {
-            foreach (self::characters() as $style => $character) {
+            foreach (Indent::CHARACTERS as $style => $character) {
                 $string = \str_repeat(
                     $character,
                     $size
@@ -226,14 +233,12 @@ JSON
      */
     public function providerPureIndentAndSniffedIndent(): \Generator
     {
-        $characters = [
-            'space' => ' ',
-            'tab' => "\t",
+        $sizes = [
+            1,
+            3,
         ];
 
-        $sizes = [1, 3];
-
-        foreach ($characters as $style => $character) {
+        foreach (Indent::CHARACTERS as $style => $character) {
             foreach ($sizes as $size) {
                 $key = \sprintf(
                     '%s-%d',


### PR DESCRIPTION
This PR

* [x] extracts an `Indent::CHARACTERS` constant that exposes a map of indent styles to the corresponding indent character