### PR TITLE
Fix: Prefix

### DIFF
--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -124,7 +124,7 @@ final class FormatTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerEncodedWithoutIndent
+     * @dataProvider provideEncodedWithoutIndent
      */
     public function testFromJsonReturnsFormatWithDefaultIndentIfJsonIsWithoutIndent(string $encoded): void
     {
@@ -138,7 +138,7 @@ final class FormatTest extends Framework\TestCase
     /**
      * @return \Generator<array<string>>
      */
-    public function providerEncodedWithoutIndent(): \Generator
+    public function provideEncodedWithoutIndent(): \Generator
     {
         $values = [
             'array-empty' => '[]',
@@ -162,7 +162,7 @@ final class FormatTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerWhitespaceWithoutNewLine
+     * @dataProvider provideWhitespaceWithoutNewLine
      */
     public function testFromFormatReturnsFormatWithoutFinalNewLineIfThereIsNoFinalNewLine(string $actualWhitespace): void
     {
@@ -186,7 +186,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerWhitespaceWithoutNewLine(): \Generator
+    public function provideWhitespaceWithoutNewLine(): \Generator
     {
         $characters = [
             ' ',
@@ -205,7 +205,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerWhitespaceWithNewLine
+     * @dataProvider provideWhitespaceWithNewLine
      */
     public function testFromFormatReturnsFormatWithFinalNewLineIfThereIsAtLeastOneFinalNewLine(string $actualWhitespace): void
     {
@@ -229,7 +229,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerWhitespaceWithNewLine(): \Generator
+    public function provideWhitespaceWithNewLine(): \Generator
     {
         $characters = [
             '',

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -44,7 +44,7 @@ final class IndentTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerInvalidSize
+     * @dataProvider provideInvalidSize
      */
     public function testFromSizeAndStyleRejectsInvalidSize(int $size): void
     {
@@ -61,7 +61,7 @@ final class IndentTest extends Framework\TestCase
     /**
      * @return \Generator<array<int>>
      */
-    public function providerInvalidSize(): \Generator
+    public function provideInvalidSize(): \Generator
     {
         $sizes = [
             'int-zero' => 0,
@@ -92,7 +92,7 @@ final class IndentTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerSizeStyleAndIndentString
+     * @dataProvider provideSizeStyleAndIndentString
      */
     public function testFromSizeAndStyleReturnsIndent(int $size, string $style, string $string): void
     {
@@ -107,7 +107,7 @@ final class IndentTest extends Framework\TestCase
     /**
      * @return \Generator<array{0: int, 1: string, 2: string}>
      */
-    public function providerSizeStyleAndIndentString(): \Generator
+    public function provideSizeStyleAndIndentString(): \Generator
     {
         foreach (self::sizes() as $key => $size) {
             foreach (Indent::CHARACTERS as $style => $character) {
@@ -126,7 +126,7 @@ final class IndentTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerInvalidIndentString
+     * @dataProvider provideInvalidIndentString
      */
     public function testFromStringRejectsInvalidIndentString(string $string): void
     {
@@ -138,7 +138,7 @@ final class IndentTest extends Framework\TestCase
     /**
      * @return \Generator<array<string>>
      */
-    public function providerInvalidIndentString(): \Generator
+    public function provideInvalidIndentString(): \Generator
     {
         $strings = [
             'string-not-whitespace' => self::faker()->sentence,
@@ -154,7 +154,7 @@ final class IndentTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerValidIndentString
+     * @dataProvider provideValidIndentString
      */
     public function testFromStringReturnsIndent(string $string): void
     {
@@ -166,7 +166,7 @@ final class IndentTest extends Framework\TestCase
     /**
      * @return \Generator<array<string>>
      */
-    public function providerValidIndentString(): \Generator
+    public function provideValidIndentString(): \Generator
     {
         foreach (self::sizes() as $key => $size) {
             foreach (Indent::CHARACTERS as $style => $character) {
@@ -183,8 +183,8 @@ final class IndentTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerMixedIndentAndSniffedIndent
-     * @dataProvider providerPureIndentAndSniffedIndent
+     * @dataProvider provideMixedIndentAndSniffedIndent
+     * @dataProvider providePureIndentAndSniffedIndent
      */
     public function testFromJsonReturnsIndentSniffedFromArray(string $actualIndent, string $sniffedIndent): void
     {
@@ -206,8 +206,8 @@ JSON
     }
 
     /**
-     * @dataProvider providerMixedIndentAndSniffedIndent
-     * @dataProvider providerPureIndentAndSniffedIndent
+     * @dataProvider provideMixedIndentAndSniffedIndent
+     * @dataProvider providePureIndentAndSniffedIndent
      */
     public function testFromJsonReturnsIndentSniffedFromObject(string $actualIndent, string $sniffedIndent): void
     {
@@ -231,7 +231,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerPureIndentAndSniffedIndent(): \Generator
+    public function providePureIndentAndSniffedIndent(): \Generator
     {
         $sizes = [
             1,
@@ -262,7 +262,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerMixedIndentAndSniffedIndent(): \Generator
+    public function provideMixedIndentAndSniffedIndent(): \Generator
     {
         $mixedIndents = [
             'space-and-tab' => [

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -32,7 +32,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
     use Helper;
 
     /**
-     * @dataProvider providerInvalidValue
+     * @dataProvider provideInvalidValue
      */
     public function testFromIntRejectsInvalidValue(int $value): void
     {
@@ -44,7 +44,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
     /**
      * @return \Generator<array<int>>
      */
-    public function providerInvalidValue(): \Generator
+    public function provideInvalidValue(): \Generator
     {
         $values = [
             'int-minus-one' => -1,
@@ -59,7 +59,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerValidValue
+     * @dataProvider provideValidValue
      */
     public function testFromIntReturnsJsonEncodeOptions(int $value): void
     {
@@ -71,7 +71,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
     /**
      * @return \Generator<array<int>>
      */
-    public function providerValidValue(): \Generator
+    public function provideValidValue(): \Generator
     {
         $values = [
             'int-zero' => 0,
@@ -86,7 +86,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerJsonEncodeOptionsAndEncoded
+     * @dataProvider provideJsonEncodeOptionsAndEncoded
      */
     public function testFromJsonReturnsJsonEncodeOptions(int $value, string $encoded): void
     {
@@ -100,7 +100,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
     /**
      * @return array<array{0: int, 1: string}>
      */
-    public function providerJsonEncodeOptionsAndEncoded(): array
+    public function provideJsonEncodeOptionsAndEncoded(): array
     {
         return [
             [

--- a/test/Unit/Format/NewLineTest.php
+++ b/test/Unit/Format/NewLineTest.php
@@ -29,7 +29,7 @@ use PHPUnit\Framework;
 final class NewLineTest extends Framework\TestCase
 {
     /**
-     * @dataProvider providerInvalidNewLineString
+     * @dataProvider provideInvalidNewLineString
      */
     public function testFromStringRejectsInvalidNewLineString(string $string): void
     {
@@ -41,7 +41,7 @@ final class NewLineTest extends Framework\TestCase
     /**
      * @return \Generator<array<string>>
      */
-    public function providerInvalidNewLineString(): \Generator
+    public function provideInvalidNewLineString(): \Generator
     {
         $strings = [
             "\t",
@@ -62,7 +62,7 @@ final class NewLineTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerValidNewLineString
+     * @dataProvider provideValidNewLineString
      */
     public function testFromStringReturnsNewLine(string $string): void
     {
@@ -74,7 +74,7 @@ final class NewLineTest extends Framework\TestCase
     /**
      * @return \Generator<array<string>>
      */
-    public function providerValidNewLineString(): \Generator
+    public function provideValidNewLineString(): \Generator
     {
         $strings = [
             "\n",
@@ -101,7 +101,7 @@ final class NewLineTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerNewLine
+     * @dataProvider provideNewLine
      */
     public function testFromFormatReturnsFormatWithNewLineSniffedFromArray(string $newLineString): void
     {
@@ -117,7 +117,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerNewLine
+     * @dataProvider provideNewLine
      */
     public function testFromFormatReturnsFormatWithNewLineNewLineSniffedFromObject(string $newLineString): void
     {
@@ -135,7 +135,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerNewLine(): \Generator
+    public function provideNewLine(): \Generator
     {
         $values = [
             "\r\n",

--- a/test/Unit/JsonEncodeNormalizerTest.php
+++ b/test/Unit/JsonEncodeNormalizerTest.php
@@ -28,7 +28,7 @@ use Ergebnis\Json\Normalizer\JsonEncodeNormalizer;
 final class JsonEncodeNormalizerTest extends AbstractNormalizerTestCase
 {
     /**
-     * @dataProvider providerJsonEncodeOptions
+     * @dataProvider provideJsonEncodeOptions
      */
     public function testNormalizeDecodesAndEncodesJsonWithJsonEncodeOptions(int $jsonEncodeOptions): void
     {
@@ -60,7 +60,7 @@ JSON
     /**
      * @return \Generator<array<int>>
      */
-    public function providerJsonEncodeOptions(): \Generator
+    public function provideJsonEncodeOptions(): \Generator
     {
         /**
          * Could add more, but the idea counts.

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -44,7 +44,7 @@ final class JsonTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerEncoded
+     * @dataProvider provideEncoded
      */
     public function testFromEncodedReturnsJson(string $encoded): void
     {
@@ -65,7 +65,7 @@ final class JsonTest extends Framework\TestCase
     /**
      * @return \Generator<array<null|array|bool|float|int|string>>
      */
-    public function providerEncoded(): \Generator
+    public function provideEncoded(): \Generator
     {
         $values = [
             'array-indexed' => [

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -307,7 +307,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerExpectedEncodedAndSchemaUri
+     * @dataProvider provideExpectedEncodedAndSchemaUri
      */
     public function testNormalizeNormalizes(string $expected, string $encoded, string $schemaUri): void
     {
@@ -327,7 +327,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerExpectedEncodedAndSchemaUri(): \Generator
+    public function provideExpectedEncodedAndSchemaUri(): \Generator
     {
         $basePath = __DIR__ . '/../';
 

--- a/test/Unit/Vendor/Composer/AbstractComposerTestCase.php
+++ b/test/Unit/Vendor/Composer/AbstractComposerTestCase.php
@@ -23,7 +23,7 @@ use Ergebnis\Json\Normalizer\Test\Unit\AbstractNormalizerTestCase;
 abstract class AbstractComposerTestCase extends AbstractNormalizerTestCase
 {
     /**
-     * @dataProvider providerJsonNotDecodingToObject
+     * @dataProvider provideJsonNotDecodingToObject
      */
     final public function testNormalizeDoesNotModifyWhenJsonDecodedIsNotAnObject(string $encoded): void
     {
@@ -45,7 +45,7 @@ abstract class AbstractComposerTestCase extends AbstractNormalizerTestCase
     /**
      * @return \Generator<array<string>>
      */
-    final public function providerJsonNotDecodingToObject(): \Generator
+    final public function provideJsonNotDecodingToObject(): \Generator
     {
         $faker = self::faker();
 

--- a/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
@@ -46,7 +46,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerProperty
+     * @dataProvider provideProperty
      */
     public function testNormalizeIgnoresEmptyConfigHash(string $property): void
     {
@@ -66,7 +66,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerProperty
+     * @dataProvider provideProperty
      */
     public function testNormalizeSortsConfigHashIfPropertyExists(string $property): void
     {
@@ -110,7 +110,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerProperty(): \Generator
+    public function provideProperty(): \Generator
     {
         foreach (self::properties() as $value) {
             yield $value => [

--- a/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
@@ -46,7 +46,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerProperty
+     * @dataProvider provideProperty
      */
     public function testNormalizeIgnoresEmptyPackageHash(string $property): void
     {
@@ -66,7 +66,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerProperty
+     * @dataProvider provideProperty
      */
     public function testNormalizeSortsPackageHashIfPropertyExists(string $property): void
     {
@@ -118,7 +118,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerProperty(): \Generator
+    public function provideProperty(): \Generator
     {
         foreach (self::propertiesWhereKeysOfHashArePackages() as $value) {
             yield $value => [

--- a/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
@@ -26,7 +26,7 @@ use Ergebnis\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer;
 final class VersionConstraintNormalizerTest extends AbstractComposerTestCase
 {
     /**
-     * @dataProvider providerVersionConstraint
+     * @dataProvider provideVersionConstraint
      */
     public function testNormalizeDoesNotModifyOtherProperty(string $constraint): void
     {
@@ -50,7 +50,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerVersionConstraint(): \Generator
+    public function provideVersionConstraint(): \Generator
     {
         foreach (\array_keys(self::versionConstraints()) as $versionConstraint) {
             yield [
@@ -60,7 +60,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerProperty
+     * @dataProvider provideProperty
      */
     public function testNormalizeIgnoresEmptyPackageHash(string $property): void
     {
@@ -82,7 +82,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerProperty(): \Generator
+    public function provideProperty(): \Generator
     {
         $properties = self::propertiesWhereValuesOfHashAreVersionConstraints();
 
@@ -94,7 +94,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerPropertyAndVersionConstraint
+     * @dataProvider providePropertyAndVersionConstraint
      */
     public function testNormalizeNormalizesVersionConstraints(string $property, string $versionConstraint, string $normalizedVersionConstraint): void
     {
@@ -128,7 +128,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerPropertyAndVersionConstraint(): \Generator
+    public function providePropertyAndVersionConstraint(): \Generator
     {
         $properties = self::propertiesWhereValuesOfHashAreVersionConstraints();
         $versionConstraints = self::versionConstraints();
@@ -145,7 +145,7 @@ JSON
     }
 
     /**
-     * @dataProvider providerPropertyAndUntrimmedVersionConstraint
+     * @dataProvider providePropertyAndUntrimmedVersionConstraint
      */
     public function testNormalizeNormalizesTrimsVersionConstraints(string $property, string $versionConstraint, string $trimmedVersionConstraint): void
     {
@@ -179,7 +179,7 @@ JSON
     /**
      * @return \Generator<array<string>>
      */
-    public function providerPropertyAndUntrimmedVersionConstraint(): \Generator
+    public function providePropertyAndUntrimmedVersionConstraint(): \Generator
     {
         $spaces = [
             '',


### PR DESCRIPTION
This PR

* [x] uses `provide` instead of `provider` as prefix for data provider methods