### PR TITLE
Enhancement: Let ConfigHashNormalizer recursively sort hashes by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.14.1...main`][0.14.1...main].
+For a full diff see [`1.0.0...main`][1.0.0...main].
+
+## [`1.0.0`][1.0.0]
+
+For a full diff see [`0.14.1...1.0.0`][0.14.1...1.0.0].
+
+### Changed
+
+* Adjusted `Vendor\Composer\ConfigHashNormalizer` to recursively sort hashes by key ([#424]), by [@localheinz]
 
 ## [`0.14.1`][0.14.1]
 
@@ -284,6 +292,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.13.1]: https://github.com/ergebnis/json-normalizer/releases/tag/0.13.1
 [0.14.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.14.0
 [0.14.1]: https://github.com/ergebnis/json-normalizer/releases/tag/0.14.1
+[1.0.0]: https://github.com/ergebnis/json-normalizer/releases/tag/1.0.0
 
 [5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
@@ -304,7 +313,8 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.13.0...0.13.1]: https://github.com/ergebnis/json-normalizer/compare/0.13.0...0.13.1
 [0.13.1...0.14.0]: https://github.com/ergebnis/json-normalizer/compare/0.13.1...0.14.0
 [0.14.0...0.14.1]: https://github.com/ergebnis/json-normalizer/compare/0.14.0...0.14.1
-[0.14.1...main]: https://github.com/ergebnis/json-normalizer/compare/0.14.1...main
+[0.14.1...1.0.0]: https://github.com/ergebnis/json-normalizer/compare/0.14.1...1.0.0
+[1.0.0...main]: https://github.com/ergebnis/json-normalizer/compare/1.0.0...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2
@@ -367,6 +377,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#335]: https://github.com/ergebnis/json-normalizer/pull/335
 [#384]: https://github.com/ergebnis/json-normalizer/pull/384
 [#423]: https://github.com/ergebnis/json-normalizer/pull/423
+[#424]: https://github.com/ergebnis/json-normalizer/pull/424
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@ergebnis]: https://github.com/ergebnis

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ When `composer.json` contains any configuration in the
 * `extra`
 * `scripts-descriptions`
 
-sections, the `Vendor\Composer\ConfigHashNormalizer` will sort the content of these sections by key in ascending order.
+sections, the `Vendor\Composer\ConfigHashNormalizer` will sort the content of these sections by key in ascending order. If a value is an object, it will continue to sort its properties by name.
 
 :bulb: Find out more about the `config` section at [Composer: The composer.json schema](https://getcomposer.org/doc/06-config.md).
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -60,12 +60,13 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Vendor/Composer/ConfigHashNormalizer.php">
+    <MixedArgument occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$value</code>
     </MixedAssignment>
-    <UnusedVariable occurrences="1">
-      <code>$value</code>
-    </UnusedVariable>
   </file>
   <file src="src/Vendor/Composer/PackageHashNormalizer.php">
     <MixedAssignment occurrences="1">

--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -48,20 +48,36 @@ final class ConfigHashNormalizer implements NormalizerInterface
         }
 
         foreach ($objectProperties as $name => $value) {
-            $config = (array) $decoded->{$name};
-
-            if (0 === \count($config)) {
-                continue;
-            }
-
-            \ksort($config);
-
-            $decoded->{$name} = $config;
+            $decoded->{$name} = self::sortByKey($value);
         }
 
         /** @var string $encoded */
         $encoded = \json_encode($decoded);
 
         return Json::fromEncoded($encoded);
+    }
+
+    /**
+     * @param null|array|bool|false|\stdClass|string $value
+     *
+     * @return null|array|bool|false|\stdClass|string
+     */
+    private static function sortByKey($value)
+    {
+        if (!\is_object($value)) {
+            return $value;
+        }
+
+        $sorted = (array) $value;
+
+        if ([] === $sorted) {
+            return $value;
+        }
+
+        \ksort($sorted);
+
+        return \array_map(static function ($value) {
+            return self::sortByKey($value);
+        }, $sorted);
     }
 }

--- a/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
@@ -141,6 +141,62 @@ JSON
     }
 
     /**
+     * @dataProvider provideProperty
+     */
+    public function testNormalizeSortsConfigHashRecursivelyIfPropertyExists(string $property): void
+    {
+        $json = Json::fromEncoded(
+            <<<JSON
+{
+  "{$property}": {
+    "sort-packages": true,
+    "preferred-install": "dist",
+    "foo": {
+      "qux": "quux",
+      "bar": {
+        "qux": "quz",
+        "baz": "qux"
+      }
+    }
+  },
+  "foo": {
+    "qux": "quux",
+    "bar": "baz"
+  }
+}
+JSON
+        );
+
+        $expected = Json::fromEncoded(
+            <<<JSON
+{
+  "{$property}": {
+    "foo": {
+      "bar": {
+        "baz": "qux",
+        "qux": "quz"
+      },
+      "qux": "quux"
+    },
+    "preferred-install": "dist",
+    "sort-packages": true
+  },
+  "foo": {
+    "qux": "quux",
+    "bar": "baz"
+  }
+}
+JSON
+        );
+
+        $normalizer = new ConfigHashNormalizer();
+
+        $normalized = $normalizer->normalize($json);
+
+        self::assertJsonStringEqualsJsonStringNormalized($expected->encoded(), $normalized->encoded());
+    }
+
+    /**
      * @return \Generator<array<string>>
      */
     public function provideProperty(): \Generator


### PR DESCRIPTION
This PR

* [x] adjusts the `ConfigHashNormalizer` to recursively sort hashes by key

Related to https://github.com/ergebnis/composer-normalize/issues/614.