### PR TITLE
Fix: Do not sort preferred-install hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...main`][1.0.0...main].
+For a full diff see [`1.0.1...main`][1.0.1...main].
+
+## [`1.0.1`][1.0.1]
+
+For a full diff see [`1.0.0...1.0.1`][1.0.0...1.0.1].
+
+### Fixed
+
+* Adjusted `Vendor\Composer\ConfigHashNormalizer` to ignore the `preferred-install` hash ([#425]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 
@@ -293,6 +301,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.14.0]: https://github.com/ergebnis/json-normalizer/releases/tag/0.14.0
 [0.14.1]: https://github.com/ergebnis/json-normalizer/releases/tag/0.14.1
 [1.0.0]: https://github.com/ergebnis/json-normalizer/releases/tag/1.0.0
+[1.0.1]: https://github.com/ergebnis/json-normalizer/releases/tag/1.0.1
 
 [5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
@@ -314,7 +323,8 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.13.1...0.14.0]: https://github.com/ergebnis/json-normalizer/compare/0.13.1...0.14.0
 [0.14.0...0.14.1]: https://github.com/ergebnis/json-normalizer/compare/0.14.0...0.14.1
 [0.14.1...1.0.0]: https://github.com/ergebnis/json-normalizer/compare/0.14.1...1.0.0
-[1.0.0...main]: https://github.com/ergebnis/json-normalizer/compare/1.0.0...main
+[1.0.0...1.0.1]: https://github.com/ergebnis/json-normalizer/compare/1.0.0...1.0.0
+[1.0.1...main]: https://github.com/ergebnis/json-normalizer/compare/1.0.1...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2
@@ -378,6 +388,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#384]: https://github.com/ergebnis/json-normalizer/pull/384
 [#423]: https://github.com/ergebnis/json-normalizer/pull/423
 [#424]: https://github.com/ergebnis/json-normalizer/pull/424
+[#425]: https://github.com/ergebnis/json-normalizer/pull/425
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@ergebnis]: https://github.com/ergebnis

--- a/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
@@ -197,6 +197,49 @@ JSON
     }
 
     /**
+     * @see https://github.com/ergebnis/composer-normalize/issues/644
+     * @see https://getcomposer.org/doc/06-config.md#preferred-install
+     */
+    public function testNormalizeDoesNotSortPreferredInstall(): void
+    {
+        $json = Json::fromEncoded(
+            <<<'JSON'
+{
+  "config": {
+    "sort-packages": true,
+    "preferred-install": {
+      "foo/*": "source",
+      "bar/*": "source",
+      "*": "dist"
+    }
+  }
+}
+JSON
+        );
+
+        $expected = Json::fromEncoded(
+            <<<'JSON'
+{
+  "config": {
+    "preferred-install": {
+      "foo/*": "source",
+      "bar/*": "source",
+      "*": "dist"
+    },
+    "sort-packages": true
+  }
+}
+JSON
+        );
+
+        $normalizer = new ConfigHashNormalizer();
+
+        $normalized = $normalizer->normalize($json);
+
+        self::assertJsonStringEqualsJsonStringNormalized($expected->encoded(), $normalized->encoded());
+    }
+
+    /**
      * @return \Generator<array<string>>
      */
     public function provideProperty(): \Generator


### PR DESCRIPTION
This PR

* [x] asserts that the `preferred-install` hash is not sorted by key
* [x] stops sorting the `preferred-install` hash

Related to https://github.com/ergebnis/composer-normalize/issues/644.