### PR TITLE
Fix: Use constants

### DIFF
--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -18,25 +18,13 @@ use Ergebnis\Json\Normalizer\NormalizerInterface;
 
 final class ConfigHashNormalizer implements NormalizerInterface
 {
-    /**
-     * @phpstan-var list<string>
-     * @psalm-var list<string>
-     *
-     * @var array<int, string>
-     */
-    private static $propertiesThatShouldBeSorted = [
+    private const PROPERTIES_THAT_SHOULD_BE_SORTED = [
         'config',
         'extra',
         'scripts-descriptions',
     ];
 
-    /**
-     * @phpstan-var list<string>
-     * @psalm-var list<string>
-     *
-     * @var array<int, string>
-     */
-    private static $propertiesThatShouldNotBeSorted = [
+    private const PROPERTIES_THAT_SHOULD_NOT_BE_SORTED = [
         'preferred-install',
     ];
 
@@ -50,7 +38,7 @@ final class ConfigHashNormalizer implements NormalizerInterface
 
         $objectPropertiesThatShouldBeNormalized = \array_intersect_key(
             \get_object_vars($decoded),
-            \array_flip(self::$propertiesThatShouldBeSorted)
+            \array_flip(self::PROPERTIES_THAT_SHOULD_BE_SORTED)
         );
 
         if (0 === \count($objectPropertiesThatShouldBeNormalized)) {
@@ -77,7 +65,7 @@ final class ConfigHashNormalizer implements NormalizerInterface
      */
     private static function sortByKey(string $name, $value)
     {
-        if (\in_array($name, self::$propertiesThatShouldNotBeSorted, true)) {
+        if (\in_array($name, self::PROPERTIES_THAT_SHOULD_NOT_BE_SORTED, true)) {
             return $value;
         }
 

--- a/src/Vendor/Composer/PackageHashNormalizer.php
+++ b/src/Vendor/Composer/PackageHashNormalizer.php
@@ -23,13 +23,7 @@ final class PackageHashNormalizer implements NormalizerInterface
      */
     private const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[^/ ]+)$}i';
 
-    /**
-     * @phpstan-var list<string>
-     * @psalm-var list<string>
-     *
-     * @var array<int, string>
-     */
-    private static $propertiesThatShouldBeNormalized = [
+    private const PROPERTIES_THAT_SHOULD_BE_NORMALIZED = [
         'conflict',
         'provide',
         'replace',
@@ -48,7 +42,7 @@ final class PackageHashNormalizer implements NormalizerInterface
 
         $objectPropertiesThatShouldBeNormalized = \array_intersect_key(
             \get_object_vars($decoded),
-            \array_flip(self::$propertiesThatShouldBeNormalized)
+            \array_flip(self::PROPERTIES_THAT_SHOULD_BE_NORMALIZED)
         );
 
         if (0 === \count($objectPropertiesThatShouldBeNormalized)) {

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -18,13 +18,7 @@ use Ergebnis\Json\Normalizer\NormalizerInterface;
 
 final class VersionConstraintNormalizer implements NormalizerInterface
 {
-    /**
-     * @phpstan-var list<string>
-     * @psalm-var list<string>
-     *
-     * @var array<int, string>
-     */
-    private static $propertiesThatShouldBeNormalized = [
+    private const PROPERTIES_THAT_SHOULD_BE_NORMALIZED = [
         'conflict',
         'provide',
         'replace',
@@ -32,10 +26,7 @@ final class VersionConstraintNormalizer implements NormalizerInterface
         'require-dev',
     ];
 
-    /**
-     * @var array<string, array{0: string, 1: string}>
-     */
-    private static $map = [
+    private const MAP = [
         'and' => [
             '{\s*,\s*}',
             ',',
@@ -60,7 +51,7 @@ final class VersionConstraintNormalizer implements NormalizerInterface
 
         $objectPropertiesThatShouldBeNormalized = \array_intersect_key(
             \get_object_vars($decoded),
-            \array_flip(self::$propertiesThatShouldBeNormalized)
+            \array_flip(self::PROPERTIES_THAT_SHOULD_BE_NORMALIZED)
         );
 
         if (0 === \count($objectPropertiesThatShouldBeNormalized)) {
@@ -89,7 +80,7 @@ final class VersionConstraintNormalizer implements NormalizerInterface
     {
         $normalized = $versionConstraint;
 
-        foreach (self::$map as [$pattern, $glue]) {
+        foreach (self::MAP as [$pattern, $glue]) {
             /** @var array<int, string> $split */
             $split = \preg_split(
                 $pattern,


### PR DESCRIPTION
This PR

* [x] uses `private` constants instead of `private`, `static` fields

Follows https://github.com/ergebnis/json-normalizer/pull/425#discussion_r550367948.

/cc @Tobion