### PR TITLE
Fix: Use property path instead of property name to exclude property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.1...main`][1.0.1...main].
+For a full diff see [`1.0.2...main`][1.0.2...main].
+
+## [`1.0.2`][1.0.2]
+
+For a full diff see [`1.0.1...1.0.2`][1.0.1...1.0.2].
+
+### Fixed
+
+* Adjusted `Vendor\Composer\ConfigHashNormalizer` to take into account the full property path, not only the property name ([#429]), by [@localheinz]
 
 ## [`1.0.1`][1.0.1]
 
@@ -302,6 +310,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.14.1]: https://github.com/ergebnis/json-normalizer/releases/tag/0.14.1
 [1.0.0]: https://github.com/ergebnis/json-normalizer/releases/tag/1.0.0
 [1.0.1]: https://github.com/ergebnis/json-normalizer/releases/tag/1.0.1
+[1.0.2]: https://github.com/ergebnis/json-normalizer/releases/tag/1.0.2
 
 [5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
@@ -324,7 +333,8 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [0.14.0...0.14.1]: https://github.com/ergebnis/json-normalizer/compare/0.14.0...0.14.1
 [0.14.1...1.0.0]: https://github.com/ergebnis/json-normalizer/compare/0.14.1...1.0.0
 [1.0.0...1.0.1]: https://github.com/ergebnis/json-normalizer/compare/1.0.0...1.0.0
-[1.0.1...main]: https://github.com/ergebnis/json-normalizer/compare/1.0.1...main
+[1.0.1...1.0.2]: https://github.com/ergebnis/json-normalizer/compare/1.0.1...1.0.2
+[1.0.2...main]: https://github.com/ergebnis/json-normalizer/compare/1.0.2...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2
@@ -389,6 +399,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#423]: https://github.com/ergebnis/json-normalizer/pull/423
 [#424]: https://github.com/ergebnis/json-normalizer/pull/424
 [#425]: https://github.com/ergebnis/json-normalizer/pull/425
+[#429]: https://github.com/ergebnis/json-normalizer/pull/429
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@ergebnis]: https://github.com/ergebnis

--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -27,8 +27,8 @@ final class ConfigHashNormalizer implements NormalizerInterface
     /**
      * @see https://getcomposer.org/doc/06-config.md#preferred-install
      */
-    private const PROPERTIES_THAT_SHOULD_NOT_BE_SORTED = [
-        'preferred-install',
+    private const PROPERTY_PATHS_THAT_SHOULD_NOT_BE_SORTED = [
+        'config.preferred-install',
     ];
 
     public function normalize(Json $json): Json
@@ -66,9 +66,9 @@ final class ConfigHashNormalizer implements NormalizerInterface
      *
      * @return null|array|bool|false|\stdClass|string
      */
-    private static function sortByKey(string $name, $value)
+    private static function sortByKey(string $propertyPath, $value)
     {
-        if (\in_array($name, self::PROPERTIES_THAT_SHOULD_NOT_BE_SORTED, true)) {
+        if (\in_array($propertyPath, self::PROPERTY_PATHS_THAT_SHOULD_NOT_BE_SORTED, true)) {
             return $value;
         }
 
@@ -89,9 +89,13 @@ final class ConfigHashNormalizer implements NormalizerInterface
 
         return \array_combine(
             $names,
-            \array_map(static function ($value, string $name) {
+            \array_map(static function ($value, string $name) use ($propertyPath) {
                 return self::sortByKey(
-                    $name,
+                    \sprintf(
+                        '%s.%s',
+                        $propertyPath,
+                        $name
+                    ),
                     $value
                 );
             }, $sorted, $names)

--- a/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
@@ -200,7 +200,7 @@ JSON
      * @see https://github.com/ergebnis/composer-normalize/issues/644
      * @see https://getcomposer.org/doc/06-config.md#preferred-install
      */
-    public function testNormalizeDoesNotSortPreferredInstall(): void
+    public function testNormalizeDoesNotSortPreferredInstallInConfig(): void
     {
         $json = Json::fromEncoded(
             <<<'JSON'
@@ -227,6 +227,45 @@ JSON
       "*": "dist"
     },
     "sort-packages": true
+  }
+}
+JSON
+        );
+
+        $normalizer = new ConfigHashNormalizer();
+
+        $normalized = $normalizer->normalize($json);
+
+        self::assertJsonStringEqualsJsonStringNormalized($expected->encoded(), $normalized->encoded());
+    }
+
+    public function testNormalizeSortsPreferredInstallInOtherProperty(): void
+    {
+        $json = Json::fromEncoded(
+            <<<'JSON'
+{
+  "extra": {
+    "something": {
+      "preferred-install": {
+        "foo": "bar",
+        "bar": "baz"
+      }
+    }
+  }
+}
+JSON
+        );
+
+        $expected = Json::fromEncoded(
+            <<<'JSON'
+{
+  "extra": {
+    "something": {
+      "preferred-install": {
+        "bar": "baz",
+        "foo": "bar"
+      }
+    }
   }
 }
 JSON


### PR DESCRIPTION
This PR

* [x] asserts that other properties with the name `preferred-install`, and a possibly different meaning, are sorted
* [x] adjusts the `ConfigHashNormalizer` to take the property path into account, not the property name

Follows #425.