### PR TITLE
Fix: Correctly sort composer-plugin-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.0.2...main`][1.0.2...main].
 
+### Fixed
+
+* Adjusted `Vendor\Composer\PackageHashNormalizer` to take into account the newly addded `composer-plugin-api` as platform requirement ([#463]), by [@localheinz]
+
 ## [`1.0.2`][1.0.2]
 
 For a full diff see [`1.0.1...1.0.2`][1.0.1...1.0.2].
@@ -400,6 +404,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#424]: https://github.com/ergebnis/json-normalizer/pull/424
 [#425]: https://github.com/ergebnis/json-normalizer/pull/425
 [#429]: https://github.com/ergebnis/json-normalizer/pull/429
+[#463]: https://github.com/ergebnis/json-normalizer/pull/463
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@ergebnis]: https://github.com/ergebnis

--- a/src/Vendor/Composer/PackageHashNormalizer.php
+++ b/src/Vendor/Composer/PackageHashNormalizer.php
@@ -19,9 +19,9 @@ use Ergebnis\Json\Normalizer\NormalizerInterface;
 final class PackageHashNormalizer implements NormalizerInterface
 {
     /**
-     * @see https://github.com/composer/composer/blob/1.6.2/src/Composer/Repository/PlatformRepository.php#L27
+     * @see https://github.com/composer/composer/blob/2.0.11/src/Composer/Repository/PlatformRepository.php#L33
      */
-    private const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[^/ ]+)$}i';
+    private const PLATFORM_PACKAGE_REGEX = '{^(?:php(?:-64bit|-ipv6|-zts|-debug)?|hhvm|(?:ext|lib)-[a-z0-9](?:[_.-]?[a-z0-9]+)*|composer-(?:plugin|runtime)-api)$}iD';
 
     private const PROPERTIES_THAT_SHOULD_BE_NORMALIZED = [
         'conflict',

--- a/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
@@ -78,7 +78,9 @@ JSON
     "hhvm": "Okay",
     "lib-baz": "Maybe it helps.",
     "localheinz/php-cs-fixer-config": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
+    "acquia/drupal-environment-detector": "^1.2.0",
     "ext-foo": "Could be useful",
+    "composer-plugin-api": "^2.0.0",
     "php": "Because why not, it's great."
   },
   "foo": {
@@ -97,6 +99,8 @@ JSON
     "hhvm": "Okay",
     "ext-foo": "Could be useful",
     "lib-baz": "Maybe it helps.",
+    "composer-plugin-api": "^2.0.0",
+    "acquia/drupal-environment-detector": "^1.2.0",
     "localheinz/php-cs-fixer-config": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
     "localheinz/test-util": "Provides utilities for tests."
   },


### PR DESCRIPTION
This pull request

* [x] asserts that `composer-plugin-api` is correctly sorted

Related to https://github.com/ergebnis/composer-normalize/issues/673.
