### PR TITLE
Fix: Disallow `phpstan/extension-installer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,7 @@
   "config": {
     "allow-plugins": {
       "composer/package-versions-deprecated": true,
-      "infection/extension-installer": true,
-      "phpstan/extension-installer": true
+      "infection/extension-installer": true
     },
     "platform": {
       "php": "7.4.26"


### PR DESCRIPTION
This pull request

- [x] disallows `phpstan/extension-installer`