### PR TITLE
Fix: Disallow implicit cast to `string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`1.0.3...main`][1.0.3...main].
 
 - Dropped support for PHP 7.2 ([#564]), by [@dependabot]
 - Dropped support for PHP 7.3 ([#573]), by [@dependabot]
+- Renamed `Format::__toString()`, `Indent::__toString()`, and `Json::__toString()` to `Format::toString()`, `Indent::toString()`, and `Json::toString()`, requiring consumers to explicitly invoke methods instead of allowing to cast to `string` ([#589]), by [@dependabot]
 
 ### Fixed
 
@@ -423,6 +424,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#517]: https://github.com/ergebnis/json-normalizer/pull/517
 [#564]: https://github.com/ergebnis/json-normalizer/pull/564
 [#573]: https://github.com/ergebnis/json-normalizer/pull/573
+[#589]: https://github.com/ergebnis/json-normalizer/pull/589
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Format/Formatter.php
+++ b/src/Format/Formatter.php
@@ -37,14 +37,14 @@ final class Formatter implements FormatterInterface
 
         $printed = $this->printer->print(
             $encoded,
-            (string) $format->indent(),
-            (string) $format->newLine(),
+            $format->indent()->toString(),
+            $format->newLine()->toString(),
         );
 
         if (!$format->hasFinalNewLine()) {
             return Json::fromEncoded($printed);
         }
 
-        return Json::fromEncoded($printed . $format->newLine());
+        return Json::fromEncoded($printed . $format->newLine()->toString());
     }
 }

--- a/src/Format/Indent.php
+++ b/src/Format/Indent.php
@@ -29,11 +29,6 @@ final class Indent
         $this->string = $string;
     }
 
-    public function __toString(): string
-    {
-        return $this->string;
-    }
-
     /**
      * @throws Exception\InvalidIndentStringException
      */
@@ -88,5 +83,10 @@ final class Indent
             4,
             'space',
         );
+    }
+
+    public function toString(): string
+    {
+        return $this->string;
     }
 }

--- a/src/Format/NewLine.php
+++ b/src/Format/NewLine.php
@@ -25,11 +25,6 @@ final class NewLine
         $this->string = $string;
     }
 
-    public function __toString(): string
-    {
-        return $this->string;
-    }
-
     /**
      * @throws Exception\InvalidNewLineStringException
      */
@@ -49,5 +44,10 @@ final class NewLine
         }
 
         return self::fromString(\PHP_EOL);
+    }
+
+    public function toString(): string
+    {
+        return $this->string;
     }
 }

--- a/src/IndentNormalizer.php
+++ b/src/IndentNormalizer.php
@@ -32,7 +32,7 @@ final class IndentNormalizer implements NormalizerInterface
     {
         $withIndent = $this->printer->print(
             $json->encoded(),
-            $this->indent->__toString(),
+            $this->indent->toString(),
         );
 
         return Json::fromEncoded($withIndent);

--- a/src/Json.php
+++ b/src/Json.php
@@ -32,14 +32,6 @@ final class Json
     }
 
     /**
-     * Returns the original JSON value.
-     */
-    public function __toString(): string
-    {
-        return $this->encoded;
-    }
-
-    /**
      * @throws Exception\InvalidJsonEncodedException
      */
     public static function fromEncoded(string $encoded): self
@@ -87,5 +79,13 @@ final class Json
         }
 
         return $this->format;
+    }
+
+    /**
+     * Returns the original JSON value.
+     */
+    public function toString(): string
+    {
+        return $this->encoded;
     }
 }

--- a/test/Unit/Format/FormatTest.php
+++ b/test/Unit/Format/FormatTest.php
@@ -129,7 +129,7 @@ final class FormatTest extends Framework\TestCase
 
         $format = Format\Format::fromJson($json);
 
-        self::assertSame('    ', $format->indent()->__toString());
+        self::assertSame('    ', $format->indent()->toString());
     }
 
     /**

--- a/test/Unit/Format/FormatterTest.php
+++ b/test/Unit/Format/FormatterTest.php
@@ -87,8 +87,8 @@ JSON;
             ->method('print')
             ->with(
                 self::identicalTo($encodedWithJsonEncodeOptions),
-                self::identicalTo($format->indent()->__toString()),
-                self::identicalTo($format->newLine()->__toString()),
+                self::identicalTo($format->indent()->toString()),
+                self::identicalTo($format->newLine()->toString()),
             )
             ->willReturn($printedWithIndentAndNewLine);
 

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -101,7 +101,7 @@ final class IndentTest extends Framework\TestCase
             $style,
         );
 
-        self::assertSame($string, $indent->__toString());
+        self::assertSame($string, $indent->toString());
     }
 
     /**
@@ -160,7 +160,7 @@ final class IndentTest extends Framework\TestCase
     {
         $indent = Format\Indent::fromString($string);
 
-        self::assertSame($string, $indent->__toString());
+        self::assertSame($string, $indent->toString());
     }
 
     /**
@@ -202,7 +202,7 @@ JSON
 
         $indent = Format\Indent::fromJson($json);
 
-        self::assertSame($sniffedIndent, $indent->__toString());
+        self::assertSame($sniffedIndent, $indent->toString());
     }
 
     /**
@@ -225,7 +225,7 @@ JSON
 
         $indent = Format\Indent::fromJson($json);
 
-        self::assertSame($sniffedIndent, $indent->__toString());
+        self::assertSame($sniffedIndent, $indent->toString());
     }
 
     /**
@@ -298,7 +298,7 @@ JSON
             4,
         );
 
-        self::assertSame($default, $indent->__toString());
+        self::assertSame($default, $indent->toString());
     }
 
     /**

--- a/test/Unit/Format/NewLineTest.php
+++ b/test/Unit/Format/NewLineTest.php
@@ -68,7 +68,7 @@ final class NewLineTest extends Framework\TestCase
     {
         $newLine = Format\NewLine::fromString($string);
 
-        self::assertSame($string, $newLine->__toString());
+        self::assertSame($string, $newLine->toString());
     }
 
     /**
@@ -97,7 +97,7 @@ final class NewLineTest extends Framework\TestCase
 
         $newLine = Format\NewLine::fromJson($json);
 
-        self::assertSame(\PHP_EOL, $newLine->__toString());
+        self::assertSame(\PHP_EOL, $newLine->toString());
     }
 
     /**
@@ -113,7 +113,7 @@ JSON
 
         $newLine = Format\NewLine::fromJson($json);
 
-        self::assertSame($newLineString, $newLine->__toString());
+        self::assertSame($newLineString, $newLine->toString());
     }
 
     /**
@@ -129,7 +129,7 @@ JSON
 
         $newLine = Format\NewLine::fromJson($json);
 
-        self::assertSame($newLineString, $newLine->__toString());
+        self::assertSame($newLineString, $newLine->toString());
     }
 
     /**

--- a/test/Unit/IndentNormalizerTest.php
+++ b/test/Unit/IndentNormalizerTest.php
@@ -54,7 +54,7 @@ JSON;
             ->method('print')
             ->with(
                 self::identicalTo($json->encoded()),
-                self::identicalTo($indent->__toString()),
+                self::identicalTo($indent->toString()),
             )
             ->willReturn($indented);
 

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -50,15 +50,15 @@ final class JsonTest extends Framework\TestCase
     {
         $json = Json::fromEncoded($encoded);
 
-        self::assertSame($encoded, $json->__toString());
+        self::assertSame($encoded, $json->toString());
         self::assertSame($encoded, $json->encoded());
         self::assertSame($encoded, \json_encode($json->decoded()));
 
         $format = Format\Format::fromJson($json);
 
         self::assertSame($format->jsonEncodeOptions()->value(), $json->format()->jsonEncodeOptions()->value());
-        self::assertSame($format->indent()->__toString(), $json->format()->indent()->__toString());
-        self::assertSame($format->newLine()->__toString(), $json->format()->newLine()->__toString());
+        self::assertSame($format->indent()->toString(), $json->format()->indent()->toString());
+        self::assertSame($format->newLine()->toString(), $json->format()->newLine()->toString());
         self::assertSame($format->hasFinalNewLine(), $json->format()->hasFinalNewLine());
     }
 


### PR DESCRIPTION
This pull request

- [x] disallows implicit cast to `string`