### PR TITLE
Fix: Do not sort `allow-plugins` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`1.0.3...main`][1.0.3...main].
 ### Fixed
 
 - Updated `justinrainbow/json-schema` ([#517]), by [@dependabot]
+- Stopped sorting the newly added `allow-plugins` configuration ([#590]), by [@dependabot]
 
 ## [`1.0.3`][1.0.3]
 
@@ -425,6 +426,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#564]: https://github.com/ergebnis/json-normalizer/pull/564
 [#573]: https://github.com/ergebnis/json-normalizer/pull/573
 [#589]: https://github.com/ergebnis/json-normalizer/pull/589
+[#590]: https://github.com/ergebnis/json-normalizer/pull/590
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -25,9 +25,11 @@ final class ConfigHashNormalizer implements NormalizerInterface
     ];
 
     /**
+     * @see https://getcomposer.org/doc/06-config.md#allow-plugins
      * @see https://getcomposer.org/doc/06-config.md#preferred-install
      */
     private const PROPERTY_PATHS_THAT_SHOULD_NOT_BE_SORTED = [
+        'config.allow-plugins',
         'config.preferred-install',
     ];
 

--- a/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
@@ -197,6 +197,87 @@ JSON
     }
 
     /**
+     * @see https://getcomposer.org/doc/06-config.md#allow-plugins
+     */
+    public function testNormalizeDoesNotSortAllowPluginsInConfig(): void
+    {
+        $json = Json::fromEncoded(
+            <<<'JSON'
+{
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "foo/*": true,
+      "bar/*": false,
+      "*": true
+    }
+  }
+}
+JSON
+        );
+
+        $expected = Json::fromEncoded(
+            <<<'JSON'
+{
+  "config": {
+    "allow-plugins": {
+      "foo/*": true,
+      "bar/*": false,
+      "*": true
+    },
+    "sort-packages": true
+  }
+}
+JSON
+        );
+
+        $normalizer = new Vendor\Composer\ConfigHashNormalizer();
+
+        $normalized = $normalizer->normalize($json);
+
+        self::assertJsonStringEqualsJsonStringNormalized($expected->encoded(), $normalized->encoded());
+    }
+
+    public function testNormalizeSortsAllowPluginsInOtherProperty(): void
+    {
+        $json = Json::fromEncoded(
+            <<<'JSON'
+{
+  "extra": {
+    "something": {
+      "allowed-plugins": {
+        "foo": true,
+        "bar": false
+      }
+    }
+  }
+}
+JSON
+        );
+
+        $expected = Json::fromEncoded(
+            <<<'JSON'
+{
+  "extra": {
+    "something": {
+      "allowed-plugins": {
+        "bar": false,
+        "foo": true
+      }
+    }
+  }
+}
+JSON
+        );
+
+        $normalizer = new Vendor\Composer\ConfigHashNormalizer();
+
+        $normalized = $normalizer->normalize($json);
+
+        self::assertJsonStringEqualsJsonStringNormalized($expected->encoded(), $normalized->encoded());
+    }
+
+    /**
      * @see https://github.com/ergebnis/composer-normalize/issues/644
      * @see https://getcomposer.org/doc/06-config.md#preferred-install
      */


### PR DESCRIPTION
This pull request

- [x] asserts that the `allow-plugins` configuration option is not sorted
- [x] stops sorting the `allow-plugins` configuration option