### PR TITLE
Fix: Use methods instead of deprecated magic properties

### DIFF
--- a/test/Unit/Exception/InvalidIndentStringExceptionTest.php
+++ b/test/Unit/Exception/InvalidIndentStringExceptionTest.php
@@ -31,7 +31,7 @@ final class InvalidIndentStringExceptionTest extends AbstractExceptionTestCase
 
     public function testFromSizeAndMinimumSizeReturnsInvalidIndentStringException(): void
     {
-        $string = self::faker()->word;
+        $string = self::faker()->word();
 
         $exception = Exception\InvalidIndentStringException::fromString($string);
 

--- a/test/Unit/Exception/InvalidIndentStyleExceptionTest.php
+++ b/test/Unit/Exception/InvalidIndentStyleExceptionTest.php
@@ -34,10 +34,10 @@ final class InvalidIndentStyleExceptionTest extends AbstractExceptionTestCase
     {
         $faker = self::faker();
 
-        $style = $faker->word;
+        $style = $faker->word();
 
         /** @var string[] $allowedStyles */
-        $allowedStyles = $faker->words;
+        $allowedStyles = $faker->words();
 
         $exception = Exception\InvalidIndentStyleException::fromStyleAndAllowedStyles(
             $style,

--- a/test/Unit/Exception/InvalidJsonEncodedExceptionTest.php
+++ b/test/Unit/Exception/InvalidJsonEncodedExceptionTest.php
@@ -31,7 +31,7 @@ final class InvalidJsonEncodedExceptionTest extends AbstractExceptionTestCase
 
     public function testFromEncodedReturnsInvalidJsonEncodedException(): void
     {
-        $encoded = self::faker()->sentence;
+        $encoded = self::faker()->sentence();
 
         $exception = Exception\InvalidJsonEncodedException::fromEncoded($encoded);
 

--- a/test/Unit/Exception/InvalidNewLineStringExceptionTest.php
+++ b/test/Unit/Exception/InvalidNewLineStringExceptionTest.php
@@ -31,7 +31,7 @@ final class InvalidNewLineStringExceptionTest extends AbstractExceptionTestCase
 
     public function testFromSizeAndMinimumSizeReturnsInvalidIndentStringException(): void
     {
-        $string = self::faker()->word;
+        $string = self::faker()->word();
 
         $exception = Exception\InvalidNewLineStringException::fromString($string);
 

--- a/test/Unit/Exception/NormalizedInvalidAccordingToSchemaExceptionTest.php
+++ b/test/Unit/Exception/NormalizedInvalidAccordingToSchemaExceptionTest.php
@@ -34,12 +34,12 @@ final class NormalizedInvalidAccordingToSchemaExceptionTest extends AbstractExce
     {
         $faker = self::faker();
 
-        $schemaUri = $faker->url;
+        $schemaUri = $faker->url();
 
         $errors = [
-            $faker->sentence,
-            $faker->sentence,
-            $faker->sentence,
+            $faker->sentence(),
+            $faker->sentence(),
+            $faker->sentence(),
         ];
 
         $exception = Exception\NormalizedInvalidAccordingToSchemaException::fromSchemaUriAndErrors(

--- a/test/Unit/Exception/OriginalInvalidAccordingToSchemaExceptionTest.php
+++ b/test/Unit/Exception/OriginalInvalidAccordingToSchemaExceptionTest.php
@@ -34,12 +34,12 @@ final class OriginalInvalidAccordingToSchemaExceptionTest extends AbstractExcept
     {
         $faker = self::faker();
 
-        $schemaUri = $faker->url;
+        $schemaUri = $faker->url();
 
         $errors = [
-            $faker->sentence,
-            $faker->sentence,
-            $faker->sentence,
+            $faker->sentence(),
+            $faker->sentence(),
+            $faker->sentence(),
         ];
 
         $exception = Exception\OriginalInvalidAccordingToSchemaException::fromSchemaUriAndErrors(

--- a/test/Unit/Exception/SchemaUriCouldNotBeReadExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriCouldNotBeReadExceptionTest.php
@@ -31,7 +31,7 @@ final class SchemaUriCouldNotBeReadExceptionTest extends AbstractExceptionTestCa
 
     public function testFromSchemaUriReturnsSchemaUriCouldNotBeReadException(): void
     {
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $exception = Exception\SchemaUriCouldNotBeReadException::fromSchemaUri($schemaUri);
 

--- a/test/Unit/Exception/SchemaUriCouldNotBeResolvedExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriCouldNotBeResolvedExceptionTest.php
@@ -31,7 +31,7 @@ final class SchemaUriCouldNotBeResolvedExceptionTest extends AbstractExceptionTe
 
     public function testFromSchemaUriReturnsSchemaUriCouldNotBeResolvedException(): void
     {
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $exception = Exception\SchemaUriCouldNotBeResolvedException::fromSchemaUri($schemaUri);
 

--- a/test/Unit/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest.php
@@ -31,7 +31,7 @@ final class SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest extends
 
     public function testFromSchemaUriReturnsSchemaUriReferencesDocumentWithInvalidMediaType(): void
     {
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $exception = Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException::fromSchemaUri($schemaUri);
 

--- a/test/Unit/Exception/SchemaUriReferencesInvalidJsonDocumentExceptionTest.php
+++ b/test/Unit/Exception/SchemaUriReferencesInvalidJsonDocumentExceptionTest.php
@@ -31,7 +31,7 @@ final class SchemaUriReferencesInvalidJsonDocumentExceptionTest extends Abstract
 
     public function testFromSchemaUriReturnsSchemaUriReferencesDocumentWithInvalidMediaType(): void
     {
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $exception = Exception\SchemaUriReferencesInvalidJsonDocumentException::fromSchemaUri($schemaUri);
 

--- a/test/Unit/FixedFormatNormalizerTest.php
+++ b/test/Unit/FixedFormatNormalizerTest.php
@@ -39,7 +39,7 @@ final class FixedFormatNormalizerTest extends AbstractNormalizerTestCase
             Format\JsonEncodeOptions::fromInt($faker->numberBetween(1)),
             Format\Indent::fromString("\t"),
             Format\NewLine::fromString("\r\n"),
-            $faker->boolean,
+            $faker->boolean(),
         );
 
         $json = Json::fromEncoded(

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -81,7 +81,7 @@ final class IndentTest extends Framework\TestCase
         $faker = self::faker();
 
         $size = $faker->numberBetween(1);
-        $style = $faker->sentence;
+        $style = $faker->sentence();
 
         $this->expectException(Exception\InvalidIndentStyleException::class);
 
@@ -141,7 +141,7 @@ final class IndentTest extends Framework\TestCase
     public function provideInvalidIndentString(): \Generator
     {
         $strings = [
-            'string-not-whitespace' => self::faker()->sentence,
+            'string-not-whitespace' => self::faker()->sentence(),
             'string-contains-line-feed' => " \n ",
             'string-mixed-space-and-tab' => " \t",
         ];

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -54,7 +54,7 @@ final class SchemaNormalizerTest extends AbstractNormalizerTestCase
 JSON
         );
 
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $schemaStorage = $this->createMock(SchemaStorage::class);
 
@@ -86,7 +86,7 @@ JSON
 JSON
         );
 
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $schemaStorage = $this->createMock(SchemaStorage::class);
 
@@ -118,7 +118,7 @@ JSON
 JSON
         );
 
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $schemaStorage = $this->createMock(SchemaStorage::class);
 
@@ -150,7 +150,7 @@ JSON
 JSON
         );
 
-        $schemaUri = self::faker()->url;
+        $schemaUri = self::faker()->url();
 
         $schemaStorage = $this->createMock(SchemaStorage::class);
 
@@ -184,7 +184,7 @@ JSON
 JSON
         );
 
-        $schemaUri = $faker->url;
+        $schemaUri = $faker->url();
 
         $schema = <<<'JSON'
 {
@@ -212,9 +212,9 @@ JSON;
                 self::identicalTo($schemaDecoded),
             )
             ->willReturn(Result::create(
-                $faker->sentence,
-                $faker->sentence,
-                $faker->sentence,
+                $faker->sentence(),
+                $faker->sentence(),
+                $faker->sentence(),
             ));
 
         $normalizer = new SchemaNormalizer(
@@ -241,7 +241,7 @@ JSON;
 JSON
         );
 
-        $schemaUri = $faker->url;
+        $schemaUri = $faker->url();
 
         $schema = <<<'JSON'
 {

--- a/test/Unit/Validator/ResultTest.php
+++ b/test/Unit/Validator/ResultTest.php
@@ -39,9 +39,9 @@ final class ResultTest extends Framework\TestCase
         $faker = self::faker();
 
         $errors = [
-            $faker->sentence,
-            $faker->sentence,
-            $faker->sentence,
+            $faker->sentence(),
+            $faker->sentence(),
+            $faker->sentence(),
         ];
 
         $result = Validator\Result::create(...$errors);

--- a/test/Unit/Vendor/Composer/AbstractComposerTestCase.php
+++ b/test/Unit/Vendor/Composer/AbstractComposerTestCase.php
@@ -50,13 +50,13 @@ abstract class AbstractComposerTestCase extends Test\Unit\AbstractNormalizerTest
         $faker = self::faker();
 
         $values = [
-            'array' => $faker->words,
+            'array' => $faker->words(),
             'bool-false' => false,
             'bool-true' => true,
             'float' => $faker->randomFloat(),
             'int' => $faker->randomNumber(),
             'null' => null,
-            'string' => $faker->sentence,
+            'string' => $faker->sentence(),
         ];
 
         foreach ($values as $key => $value) {


### PR DESCRIPTION
This pull request

- [x] uses methods instead of deprecated magic properties