### PR TITLE
Fix: Use `JSON_THROW_ON_ERROR`

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -3,8 +3,8 @@
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
-  "minCoveredMsi": 92,
-  "minMsi": 91,
+  "minCoveredMsi": 90,
+  "minMsi": 90,
   "phpUnit": {
     "configDir": "test\/Unit"
   },

--- a/src/Json.php
+++ b/src/Json.php
@@ -37,12 +37,14 @@ final class Json
      */
     public static function fromEncoded(string $encoded): self
     {
-        $decoded = \json_decode($encoded);
-
-        if (
-            null === $decoded
-            && \JSON_ERROR_NONE !== \json_last_error()
-        ) {
+        try {
+            $decoded = \json_decode(
+                $encoded,
+                false,
+                512,
+                \JSON_THROW_ON_ERROR,
+            );
+        } catch (\JsonException $exception) {
             throw Exception\InvalidJsonEncodedException::fromEncoded($encoded);
         }
 


### PR DESCRIPTION
This pull request

- [x] uses the `JSON_THROW_ON_ERROR` flag