### PR TITLE
Fix: Do not compose `Format` into `Json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`1.0.3...main`][1.0.3...main].
 - Started using the `SchemaValidator` provided by `ergebnis/json-schema-validator` ([#595]), by [@localheinz]
 - Renamed `Format\JsonEncodeOptions::value()` to `Format\JsonEncodeOptions::toInt()` ([#603]), by [@localheinz]
 - Extracted `Format\Format::create()` as named constructor and reduced visibility of `__construct`  to `private` ([#608]), by [@localheinz]
+- Stopped composing `Format\Format` into `Json` ([#616]), by [@localheinz]
 
 ### Fixed
 
@@ -438,6 +439,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#597]: https://github.com/ergebnis/json-normalizer/pull/597
 [#603]: https://github.com/ergebnis/json-normalizer/pull/603
 [#608]: https://github.com/ergebnis/json-normalizer/pull/608
+[#616]: https://github.com/ergebnis/json-normalizer/pull/616
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/AutoFormatNormalizer.php
+++ b/src/AutoFormatNormalizer.php
@@ -28,9 +28,11 @@ final class AutoFormatNormalizer implements NormalizerInterface
 
     public function normalize(Json $json): Json
     {
+        $format = Format\Format::fromJson($json);
+
         return $this->formatter->format(
             $this->normalizer->normalize($json),
-            $json->format(),
+            $format,
         );
     }
 }

--- a/src/Json.php
+++ b/src/Json.php
@@ -24,7 +24,6 @@ final class Json
      * @var null|array<mixed>|bool|float|int|\stdClass|string
      */
     private $decoded;
-    private Format\Format $format;
 
     private function __construct(
         string $encoded,
@@ -32,7 +31,6 @@ final class Json
     ) {
         $this->encoded = $encoded;
         $this->decoded = $decoded;
-        $this->format = Format\Format::fromJson($this);
     }
 
     /**
@@ -73,14 +71,6 @@ final class Json
     public function encoded(): string
     {
         return $this->encoded;
-    }
-
-    /**
-     * Returns the format of the original JSON value.
-     */
-    public function format(): Format\Format
-    {
-        return $this->format;
     }
 
     /**

--- a/test/Unit/AutoFormatNormalizerTest.php
+++ b/test/Unit/AutoFormatNormalizerTest.php
@@ -72,7 +72,7 @@ JSON
             ->method('format')
             ->with(
                 self::identicalTo($normalized),
-                self::identicalTo($json->format()),
+                self::equalTo(Format\Format::fromJson($json)),
             )
             ->willReturn($formatted);
 

--- a/test/Unit/CallableNormalizerTest.php
+++ b/test/Unit/CallableNormalizerTest.php
@@ -21,10 +21,6 @@ use Ergebnis\Json\Normalizer\Json;
  *
  * @covers \Ergebnis\Json\Normalizer\CallableNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class CallableNormalizerTest extends AbstractNormalizerTestCase

--- a/test/Unit/ChainNormalizerTest.php
+++ b/test/Unit/ChainNormalizerTest.php
@@ -22,10 +22,6 @@ use Ergebnis\Json\Normalizer\NormalizerInterface;
  *
  * @covers \Ergebnis\Json\Normalizer\ChainNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class ChainNormalizerTest extends AbstractNormalizerTestCase

--- a/test/Unit/FinalNewLineNormalizerTest.php
+++ b/test/Unit/FinalNewLineNormalizerTest.php
@@ -21,10 +21,6 @@ use Ergebnis\Json\Normalizer\Json;
  *
  * @covers \Ergebnis\Json\Normalizer\FinalNewLineNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class FinalNewLineNormalizerTest extends AbstractNormalizerTestCase

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -27,9 +27,6 @@ use PHPUnit\Framework;
  * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentSizeException
  * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentStringException
  * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentStyleException
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class IndentTest extends Framework\TestCase

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -25,10 +25,6 @@ use PHPUnit\Framework;
  * @covers \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  *
  * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class JsonEncodeOptionsTest extends Framework\TestCase

--- a/test/Unit/Format/NewLineTest.php
+++ b/test/Unit/Format/NewLineTest.php
@@ -24,10 +24,6 @@ use PHPUnit\Framework;
  * @covers \Ergebnis\Json\Normalizer\Format\NewLine
  *
  * @uses \Ergebnis\Json\Normalizer\Exception\InvalidNewLineStringException
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class NewLineTest extends Framework\TestCase

--- a/test/Unit/IndentNormalizerTest.php
+++ b/test/Unit/IndentNormalizerTest.php
@@ -23,10 +23,7 @@ use Ergebnis\Json\Printer\PrinterInterface;
  *
  * @covers \Ergebnis\Json\Normalizer\IndentNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
  * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class IndentNormalizerTest extends AbstractNormalizerTestCase

--- a/test/Unit/JsonEncodeNormalizerTest.php
+++ b/test/Unit/JsonEncodeNormalizerTest.php
@@ -22,10 +22,7 @@ use Ergebnis\Json\Normalizer\JsonEncodeNormalizer;
  *
  * @covers \Ergebnis\Json\Normalizer\JsonEncodeNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
  * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class JsonEncodeNormalizerTest extends AbstractNormalizerTestCase

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Test\Unit;
 
 use Ergebnis\Json\Normalizer\Exception;
-use Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Normalizer\Test;
 use PHPUnit\Framework;
@@ -25,10 +24,6 @@ use PHPUnit\Framework;
  * @covers \Ergebnis\Json\Normalizer\Json
  *
  * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodedException
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  */
 final class JsonTest extends Framework\TestCase
 {
@@ -53,10 +48,6 @@ final class JsonTest extends Framework\TestCase
         self::assertSame($encoded, $json->toString());
         self::assertSame($encoded, $json->encoded());
         self::assertSame($encoded, \json_encode($json->decoded()));
-
-        $format = Format\Format::fromJson($json);
-
-        self::assertEquals($format, $json->format());
     }
 
     /**

--- a/test/Unit/NoFinalNewLineNormalizerTest.php
+++ b/test/Unit/NoFinalNewLineNormalizerTest.php
@@ -21,10 +21,6 @@ use Ergebnis\Json\Normalizer\NoFinalNewLineNormalizer;
  *
  * @covers \Ergebnis\Json\Normalizer\NoFinalNewLineNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class NoFinalNewLineNormalizerTest extends AbstractNormalizerTestCase

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -34,10 +34,6 @@ use JsonSchema\SchemaStorage;
  * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException
  * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
  * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class SchemaNormalizerTest extends AbstractNormalizerTestCase

--- a/test/Unit/Vendor/Composer/BinNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/BinNormalizerTest.php
@@ -21,10 +21,6 @@ use Ergebnis\Json\Normalizer\Vendor;
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\BinNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class BinNormalizerTest extends AbstractComposerTestCase

--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -25,10 +25,6 @@ use Ergebnis\Json\Normalizer\Vendor;
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\ComposerJsonNormalizer
  *
  * @uses \Ergebnis\Json\Normalizer\ChainNormalizer
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  * @uses \Ergebnis\Json\Normalizer\SchemaNormalizer
  * @uses \Ergebnis\Json\Normalizer\Vendor\Composer\BinNormalizer

--- a/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ConfigHashNormalizerTest.php
@@ -21,10 +21,6 @@ use Ergebnis\Json\Normalizer\Vendor;
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\ConfigHashNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class ConfigHashNormalizerTest extends AbstractComposerTestCase

--- a/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
@@ -21,10 +21,6 @@ use Ergebnis\Json\Normalizer\Vendor;
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\PackageHashNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class PackageHashNormalizerTest extends AbstractComposerTestCase

--- a/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
@@ -21,10 +21,6 @@ use Ergebnis\Json\Normalizer\Vendor;
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Format\Format
- * @uses \Ergebnis\Json\Normalizer\Format\Indent
- * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
- * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class VersionConstraintNormalizerTest extends AbstractComposerTestCase


### PR DESCRIPTION
This pull request

- [x] stops composing `Format` into `Json`