### PR TITLE
Fix: Assert that `config.allow-plugins` is not sorted

### DIFF
--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -82,6 +82,10 @@ final class ComposerJsonNormalizerTest extends AbstractComposerTestCase
   ],
   "config": {
     "sort-packages": true,
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
+    },
     "preferred-install": "dist"
   },
   "repositories": [
@@ -162,6 +166,10 @@ JSON
     "phpunit/phpunit": "^6.5.5"
   },
   "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true,
+      "ergebnis/*": false
+    },
     "preferred-install": "dist",
     "sort-packages": true
   },


### PR DESCRIPTION
This pull request

- [x] asserts that `config.allow-plugins` is not sorted