### PR TITLE
Fix: Rename interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.2.0...main`][2.2.0...main].
+For a full diff see [`3.0.0...main`][3.0.0...main].
+
+## [`3.0.0`][3.0.0]
+
+For a full diff see [`2.2.0...3.0.0`][2.2.0...3.0.0].
 
 ### Changed
 
 - Required `ergebnis/json-schema-validator:^3.0.0` ([#666]), by [@dependabot]
+- Renamed `Exception\ExceptionInterface` to `Exception\Exception` ([#667]), by [@dependabot]
 
 ## [`2.2.0`][2.2.0]
 
@@ -370,6 +375,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [2.0.0]: https://github.com/ergebnis/json-normalizer/releases/tag/2.0.0
 [2.1.0]: https://github.com/ergebnis/json-normalizer/releases/tag/2.1.0
 [2.2.0]: https://github.com/ergebnis/json-normalizer/releases/tag/2.2.0
+[3.0.0]: https://github.com/ergebnis/json-normalizer/releases/tag/3.0.0
 
 [5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
@@ -397,7 +403,8 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [1.0.3...2.0.0]: https://github.com/ergebnis/json-normalizer/compare/1.0.3...2.0.0
 [2.0.0...2.1.0]: https://github.com/ergebnis/json-normalizer/compare/2.0.0...2.1.0
 [2.1.0...2.2.0]: https://github.com/ergebnis/json-normalizer/compare/2.1.0...2.2.0
-[2.2.0...main]: https://github.com/ergebnis/json-normalizer/compare/2.2.0...main
+[2.2.0...3.0.0]: https://github.com/ergebnis/json-normalizer/compare/2.2.0...3.0.0
+[3.0.0...main]: https://github.com/ergebnis/json-normalizer/compare/3.0.0...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2
@@ -481,6 +488,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#639]: https://github.com/ergebnis/json-normalizer/pull/639
 [#641]: https://github.com/ergebnis/json-normalizer/pull/641
 [#666]: https://github.com/ergebnis/json-normalizer/pull/666
+[#667]: https://github.com/ergebnis/json-normalizer/pull/667
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-interface ExceptionInterface extends \Throwable
+interface Exception extends \Throwable
 {
 }

--- a/src/Exception/InvalidIndentSizeException.php
+++ b/src/Exception/InvalidIndentSizeException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidIndentSizeException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidIndentSizeException extends \InvalidArgumentException implements Exception
 {
     private int $size = 0;
     private int $minimumSize = 0;

--- a/src/Exception/InvalidIndentStringException.php
+++ b/src/Exception/InvalidIndentStringException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidIndentStringException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidIndentStringException extends \InvalidArgumentException implements Exception
 {
     private string $string = '';
 

--- a/src/Exception/InvalidIndentStyleException.php
+++ b/src/Exception/InvalidIndentStyleException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidIndentStyleException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidIndentStyleException extends \InvalidArgumentException implements Exception
 {
     private string $style = '';
 

--- a/src/Exception/InvalidJsonEncodeOptionsException.php
+++ b/src/Exception/InvalidJsonEncodeOptionsException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidJsonEncodeOptionsException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidJsonEncodeOptionsException extends \InvalidArgumentException implements Exception
 {
     private int $jsonEncodeOptions = 0;
 

--- a/src/Exception/InvalidJsonEncodedException.php
+++ b/src/Exception/InvalidJsonEncodedException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidJsonEncodedException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidJsonEncodedException extends \InvalidArgumentException implements Exception
 {
     private string $encoded = '';
 

--- a/src/Exception/InvalidNewLineStringException.php
+++ b/src/Exception/InvalidNewLineStringException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidNewLineStringException extends \InvalidArgumentException implements ExceptionInterface
+final class InvalidNewLineStringException extends \InvalidArgumentException implements Exception
 {
     private string $string = '';
 

--- a/src/Exception/NormalizedInvalidAccordingToSchemaException.php
+++ b/src/Exception/NormalizedInvalidAccordingToSchemaException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class NormalizedInvalidAccordingToSchemaException extends \RuntimeException implements ExceptionInterface
+final class NormalizedInvalidAccordingToSchemaException extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 

--- a/src/Exception/OriginalInvalidAccordingToSchemaException.php
+++ b/src/Exception/OriginalInvalidAccordingToSchemaException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class OriginalInvalidAccordingToSchemaException extends \RuntimeException implements ExceptionInterface
+final class OriginalInvalidAccordingToSchemaException extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 

--- a/src/Exception/SchemaUriCouldNotBeReadException.php
+++ b/src/Exception/SchemaUriCouldNotBeReadException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriCouldNotBeReadException extends \RuntimeException implements ExceptionInterface
+final class SchemaUriCouldNotBeReadException extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 

--- a/src/Exception/SchemaUriCouldNotBeResolvedException.php
+++ b/src/Exception/SchemaUriCouldNotBeResolvedException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriCouldNotBeResolvedException extends \RuntimeException implements ExceptionInterface
+final class SchemaUriCouldNotBeResolvedException extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 

--- a/src/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeException.php
+++ b/src/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriReferencesDocumentWithInvalidMediaTypeException extends \RuntimeException implements ExceptionInterface
+final class SchemaUriReferencesDocumentWithInvalidMediaTypeException extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 

--- a/src/Exception/SchemaUriReferencesInvalidJsonDocumentException.php
+++ b/src/Exception/SchemaUriReferencesInvalidJsonDocumentException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriReferencesInvalidJsonDocumentException extends \RuntimeException implements ExceptionInterface
+final class SchemaUriReferencesInvalidJsonDocumentException extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 


### PR DESCRIPTION
This pull request

- [x] renames `Exception\ExceptionInterface` to `Exception\Exception`