### PR TITLE
Fix: Rename exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`2.2.0...3.0.0`][2.2.0...3.0.0].
 
 - Required `ergebnis/json-schema-validator:^3.0.0` ([#666]), by [@dependabot]
 - Renamed `Exception\ExceptionInterface` to `Exception\Exception` ([#667]), by [@dependabot]
+- Removed `Exception` suffix from all exceptions ([#668]), by [@dependabot]
 
 ## [`2.2.0`][2.2.0]
 
@@ -489,6 +490,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#641]: https://github.com/ergebnis/json-normalizer/pull/641
 [#666]: https://github.com/ergebnis/json-normalizer/pull/666
 [#667]: https://github.com/ergebnis/json-normalizer/pull/667
+[#668]: https://github.com/ergebnis/json-normalizer/pull/668
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Exception/InvalidIndentSize.php
+++ b/src/Exception/InvalidIndentSize.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidIndentSizeException extends \InvalidArgumentException implements Exception
+final class InvalidIndentSize extends \InvalidArgumentException implements Exception
 {
     private int $size = 0;
     private int $minimumSize = 0;

--- a/src/Exception/InvalidIndentString.php
+++ b/src/Exception/InvalidIndentString.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidNewLineStringException extends \InvalidArgumentException implements Exception
+final class InvalidIndentString extends \InvalidArgumentException implements Exception
 {
     private string $string = '';
 
     public static function fromString(string $string): self
     {
         $exception = new self(\sprintf(
-            '"%s" is not a valid new-line character sequence.',
+            '"%s" is not a valid indent string',
             $string,
         ));
 

--- a/src/Exception/InvalidIndentStyle.php
+++ b/src/Exception/InvalidIndentStyle.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidIndentStyleException extends \InvalidArgumentException implements Exception
+final class InvalidIndentStyle extends \InvalidArgumentException implements Exception
 {
     private string $style = '';
 

--- a/src/Exception/InvalidJsonEncodeOptions.php
+++ b/src/Exception/InvalidJsonEncodeOptions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidJsonEncodeOptionsException extends \InvalidArgumentException implements Exception
+final class InvalidJsonEncodeOptions extends \InvalidArgumentException implements Exception
 {
     private int $jsonEncodeOptions = 0;
 

--- a/src/Exception/InvalidJsonEncoded.php
+++ b/src/Exception/InvalidJsonEncoded.php
@@ -13,24 +13,24 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriCouldNotBeResolvedException extends \RuntimeException implements Exception
+final class InvalidJsonEncoded extends \InvalidArgumentException implements Exception
 {
-    private string $schemaUri = '';
+    private string $encoded = '';
 
-    public static function fromSchemaUri(string $schemaUri): self
+    public static function fromEncoded(string $encoded): self
     {
         $exception = new self(\sprintf(
-            'Schema URI "%s" could not be resolved.',
-            $schemaUri,
+            '"%s" is not valid JSON.',
+            $encoded,
         ));
 
-        $exception->schemaUri = $schemaUri;
+        $exception->encoded = $encoded;
 
         return $exception;
     }
 
-    public function schemaUri(): string
+    public function encoded(): string
     {
-        return $this->schemaUri;
+        return $this->encoded;
     }
 }

--- a/src/Exception/InvalidNewLineString.php
+++ b/src/Exception/InvalidNewLineString.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidIndentStringException extends \InvalidArgumentException implements Exception
+final class InvalidNewLineString extends \InvalidArgumentException implements Exception
 {
     private string $string = '';
 
     public static function fromString(string $string): self
     {
         $exception = new self(\sprintf(
-            '"%s" is not a valid indent string',
+            '"%s" is not a valid new-line character sequence.',
             $string,
         ));
 

--- a/src/Exception/NormalizedInvalidAccordingToSchema.php
+++ b/src/Exception/NormalizedInvalidAccordingToSchema.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class NormalizedInvalidAccordingToSchemaException extends \RuntimeException implements Exception
+final class NormalizedInvalidAccordingToSchema extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 

--- a/src/Exception/OriginalInvalidAccordingToSchema.php
+++ b/src/Exception/OriginalInvalidAccordingToSchema.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class OriginalInvalidAccordingToSchemaException extends \RuntimeException implements Exception
+final class OriginalInvalidAccordingToSchema extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 

--- a/src/Exception/SchemaUriCouldNotBeRead.php
+++ b/src/Exception/SchemaUriCouldNotBeRead.php
@@ -13,24 +13,24 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class InvalidJsonEncodedException extends \InvalidArgumentException implements Exception
+final class SchemaUriCouldNotBeRead extends \RuntimeException implements Exception
 {
-    private string $encoded = '';
+    private string $schemaUri = '';
 
-    public static function fromEncoded(string $encoded): self
+    public static function fromSchemaUri(string $schemaUri): self
     {
         $exception = new self(\sprintf(
-            '"%s" is not valid JSON.',
-            $encoded,
+            'Schema URI "%s" does not reference a document that could be read.',
+            $schemaUri,
         ));
 
-        $exception->encoded = $encoded;
+        $exception->schemaUri = $schemaUri;
 
         return $exception;
     }
 
-    public function encoded(): string
+    public function schemaUri(): string
     {
-        return $this->encoded;
+        return $this->schemaUri;
     }
 }

--- a/src/Exception/SchemaUriCouldNotBeResolved.php
+++ b/src/Exception/SchemaUriCouldNotBeResolved.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriReferencesDocumentWithInvalidMediaTypeException extends \RuntimeException implements Exception
+final class SchemaUriCouldNotBeResolved extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 
     public static function fromSchemaUri(string $schemaUri): self
     {
         $exception = new self(\sprintf(
-            'Schema URI "%s" does not reference a document with media type "application/schema+json".',
+            'Schema URI "%s" could not be resolved.',
             $schemaUri,
         ));
 

--- a/src/Exception/SchemaUriReferencesDocumentWithInvalidMediaType.php
+++ b/src/Exception/SchemaUriReferencesDocumentWithInvalidMediaType.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriReferencesInvalidJsonDocumentException extends \RuntimeException implements Exception
+final class SchemaUriReferencesDocumentWithInvalidMediaType extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 
     public static function fromSchemaUri(string $schemaUri): self
     {
         $exception = new self(\sprintf(
-            'Schema URI "%s" does not reference a document with valid JSON syntax.',
+            'Schema URI "%s" does not reference a document with media type "application/schema+json".',
             $schemaUri,
         ));
 

--- a/src/Exception/SchemaUriReferencesInvalidJsonDocument.php
+++ b/src/Exception/SchemaUriReferencesInvalidJsonDocument.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer\Exception;
 
-final class SchemaUriCouldNotBeReadException extends \RuntimeException implements Exception
+final class SchemaUriReferencesInvalidJsonDocument extends \RuntimeException implements Exception
 {
     private string $schemaUri = '';
 
     public static function fromSchemaUri(string $schemaUri): self
     {
         $exception = new self(\sprintf(
-            'Schema URI "%s" does not reference a document that could be read.',
+            'Schema URI "%s" does not reference a document with valid JSON syntax.',
             $schemaUri,
         ));
 

--- a/src/Format/Indent.php
+++ b/src/Format/Indent.php
@@ -33,20 +33,20 @@ final class Indent
     }
 
     /**
-     * @throws Exception\InvalidIndentStringException
+     * @throws Exception\InvalidIndentString
      */
     public static function fromString(string $value): self
     {
         if (1 !== \preg_match('/^( *|\t+)$/', $value)) {
-            throw Exception\InvalidIndentStringException::fromString($value);
+            throw Exception\InvalidIndentString::fromString($value);
         }
 
         return new self($value);
     }
 
     /**
-     * @throws Exception\InvalidIndentSizeException
-     * @throws Exception\InvalidIndentStyleException
+     * @throws Exception\InvalidIndentSize
+     * @throws Exception\InvalidIndentStyle
      */
     public static function fromSizeAndStyle(
         int $size,
@@ -55,14 +55,14 @@ final class Indent
         $minimumSize = 1;
 
         if ($minimumSize > $size) {
-            throw Exception\InvalidIndentSizeException::fromSizeAndMinimumSize(
+            throw Exception\InvalidIndentSize::fromSizeAndMinimumSize(
                 $size,
                 $minimumSize,
             );
         }
 
         if (!\array_key_exists($style, self::CHARACTERS)) {
-            throw Exception\InvalidIndentStyleException::fromStyleAndAllowedStyles(
+            throw Exception\InvalidIndentStyle::fromStyleAndAllowedStyles(
                 $style,
                 ...\array_keys(self::CHARACTERS),
             );

--- a/src/Format/JsonEncodeOptions.php
+++ b/src/Format/JsonEncodeOptions.php
@@ -29,12 +29,12 @@ final class JsonEncodeOptions
     }
 
     /**
-     * @throws Exception\InvalidJsonEncodeOptionsException
+     * @throws Exception\InvalidJsonEncodeOptions
      */
     public static function fromInt(int $value): self
     {
         if (0 > $value) {
-            throw Exception\InvalidJsonEncodeOptionsException::fromJsonEncodeOptions($value);
+            throw Exception\InvalidJsonEncodeOptions::fromJsonEncodeOptions($value);
         }
 
         return new self($value);

--- a/src/Format/NewLine.php
+++ b/src/Format/NewLine.php
@@ -29,12 +29,12 @@ final class NewLine
     }
 
     /**
-     * @throws Exception\InvalidNewLineStringException
+     * @throws Exception\InvalidNewLineString
      */
     public static function fromString(string $value): self
     {
         if (1 !== \preg_match('/^(?>\r\n|\n|\r)$/', $value)) {
-            throw Exception\InvalidNewLineStringException::fromString($value);
+            throw Exception\InvalidNewLineString::fromString($value);
         }
 
         return new self($value);

--- a/src/Json.php
+++ b/src/Json.php
@@ -34,7 +34,7 @@ final class Json
     }
 
     /**
-     * @throws Exception\InvalidJsonEncodedException
+     * @throws Exception\InvalidJsonEncoded
      */
     public static function fromEncoded(string $encoded): self
     {
@@ -46,7 +46,7 @@ final class Json
                 \JSON_THROW_ON_ERROR,
             );
         } catch (\JsonException $exception) {
-            throw Exception\InvalidJsonEncodedException::fromEncoded($encoded);
+            throw Exception\InvalidJsonEncoded::fromEncoded($encoded);
         }
 
         return new self(

--- a/src/NormalizerInterface.php
+++ b/src/NormalizerInterface.php
@@ -16,12 +16,12 @@ namespace Ergebnis\Json\Normalizer;
 interface NormalizerInterface
 {
     /**
-     * @throws Exception\SchemaUriCouldNotBeResolvedException
-     * @throws Exception\SchemaUriCouldNotBeReadException
-     * @throws Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
-     * @throws Exception\SchemaUriReferencesInvalidJsonDocumentException
-     * @throws Exception\OriginalInvalidAccordingToSchemaException
-     * @throws Exception\NormalizedInvalidAccordingToSchemaException
+     * @throws Exception\SchemaUriCouldNotBeResolved
+     * @throws Exception\SchemaUriCouldNotBeRead
+     * @throws Exception\SchemaUriReferencesDocumentWithInvalidMediaType
+     * @throws Exception\SchemaUriReferencesInvalidJsonDocument
+     * @throws Exception\OriginalInvalidAccordingToSchema
+     * @throws Exception\NormalizedInvalidAccordingToSchema
      */
     public function normalize(Json $json): Json;
 }

--- a/src/SchemaNormalizer.php
+++ b/src/SchemaNormalizer.php
@@ -42,13 +42,13 @@ final class SchemaNormalizer implements NormalizerInterface
         try {
             $schema = $this->schemaStorage->getSchema($this->schemaUri);
         } catch (UriResolverException $exception) {
-            throw Exception\SchemaUriCouldNotBeResolvedException::fromSchemaUri($this->schemaUri);
+            throw Exception\SchemaUriCouldNotBeResolved::fromSchemaUri($this->schemaUri);
         } catch (ResourceNotFoundException $exception) {
-            throw Exception\SchemaUriCouldNotBeReadException::fromSchemaUri($this->schemaUri);
+            throw Exception\SchemaUriCouldNotBeRead::fromSchemaUri($this->schemaUri);
         } catch (InvalidSchemaMediaTypeException $exception) {
-            throw Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException::fromSchemaUri($this->schemaUri);
+            throw Exception\SchemaUriReferencesDocumentWithInvalidMediaType::fromSchemaUri($this->schemaUri);
         } catch (JsonDecodingException $exception) {
-            throw Exception\SchemaUriReferencesInvalidJsonDocumentException::fromSchemaUri($this->schemaUri);
+            throw Exception\SchemaUriReferencesInvalidJsonDocument::fromSchemaUri($this->schemaUri);
         }
 
         $resultBeforeNormalization = $this->schemaValidator->validate(
@@ -58,7 +58,7 @@ final class SchemaNormalizer implements NormalizerInterface
         );
 
         if (!$resultBeforeNormalization->isValid()) {
-            throw Exception\OriginalInvalidAccordingToSchemaException::fromSchemaUriAndErrors(
+            throw Exception\OriginalInvalidAccordingToSchema::fromSchemaUriAndErrors(
                 $this->schemaUri,
                 ...\array_map(static function (SchemaValidator\ValidationError $error): string {
                     return $error->message()->toString();
@@ -78,7 +78,7 @@ final class SchemaNormalizer implements NormalizerInterface
         );
 
         if (!$resultAfterNormalization->isValid()) {
-            throw Exception\NormalizedInvalidAccordingToSchemaException::fromSchemaUriAndErrors(
+            throw Exception\NormalizedInvalidAccordingToSchema::fromSchemaUriAndErrors(
                 $this->schemaUri,
                 ...\array_map(static function (SchemaValidator\ValidationError $error): string {
                     return $error->message()->toString();

--- a/test/Unit/Exception/InvalidIndentSizeTest.php
+++ b/test/Unit/Exception/InvalidIndentSizeTest.php
@@ -18,13 +18,13 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentSizeException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentSize
  */
-final class InvalidIndentSizeExceptionTest extends AbstractExceptionTestCase
+final class InvalidIndentSizeTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\InvalidIndentSizeException();
+        $exception = new Exception\InvalidIndentSize();
 
         self::assertSame(0, $exception->minimumSize());
         self::assertSame(0, $exception->size());
@@ -37,7 +37,7 @@ final class InvalidIndentSizeExceptionTest extends AbstractExceptionTestCase
         $size = $faker->numberBetween(1);
         $minimumSize = $faker->numberBetween(1);
 
-        $exception = Exception\InvalidIndentSizeException::fromSizeAndMinimumSize(
+        $exception = Exception\InvalidIndentSize::fromSizeAndMinimumSize(
             $size,
             $minimumSize,
         );

--- a/test/Unit/Exception/InvalidIndentStringTest.php
+++ b/test/Unit/Exception/InvalidIndentStringTest.php
@@ -18,13 +18,13 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\InvalidNewLineStringException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentString
  */
-final class InvalidNewLineStringExceptionTest extends AbstractExceptionTestCase
+final class InvalidIndentStringTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\InvalidNewLineStringException();
+        $exception = new Exception\InvalidIndentString();
 
         self::assertSame('', $exception->string());
     }
@@ -33,10 +33,10 @@ final class InvalidNewLineStringExceptionTest extends AbstractExceptionTestCase
     {
         $string = self::faker()->word();
 
-        $exception = Exception\InvalidNewLineStringException::fromString($string);
+        $exception = Exception\InvalidIndentString::fromString($string);
 
         $message = \sprintf(
-            '"%s" is not a valid new-line character sequence.',
+            '"%s" is not a valid indent string',
             $string,
         );
 

--- a/test/Unit/Exception/InvalidIndentStyleTest.php
+++ b/test/Unit/Exception/InvalidIndentStyleTest.php
@@ -18,13 +18,13 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentStyleException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentStyle
  */
-final class InvalidIndentStyleExceptionTest extends AbstractExceptionTestCase
+final class InvalidIndentStyleTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\InvalidIndentStyleException();
+        $exception = new Exception\InvalidIndentStyle();
 
         self::assertSame([], $exception->allowedStyles());
         self::assertSame('', $exception->style());
@@ -39,7 +39,7 @@ final class InvalidIndentStyleExceptionTest extends AbstractExceptionTestCase
         /** @var string[] $allowedStyles */
         $allowedStyles = $faker->words();
 
-        $exception = Exception\InvalidIndentStyleException::fromStyleAndAllowedStyles(
+        $exception = Exception\InvalidIndentStyle::fromStyleAndAllowedStyles(
             $style,
             ...$allowedStyles,
         );

--- a/test/Unit/Exception/InvalidJsonEncodeOptionsTest.php
+++ b/test/Unit/Exception/InvalidJsonEncodeOptionsTest.php
@@ -18,13 +18,13 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptions
  */
-final class InvalidJsonEncodeOptionsExceptionTest extends AbstractExceptionTestCase
+final class InvalidJsonEncodeOptionsTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\InvalidJsonEncodeOptionsException();
+        $exception = new Exception\InvalidJsonEncodeOptions();
 
         self::assertSame(0, $exception->jsonEncodeOptions());
     }
@@ -33,7 +33,7 @@ final class InvalidJsonEncodeOptionsExceptionTest extends AbstractExceptionTestC
     {
         $jsonEncodeOptions = self::faker()->randomNumber();
 
-        $exception = Exception\InvalidJsonEncodeOptionsException::fromJsonEncodeOptions($jsonEncodeOptions);
+        $exception = Exception\InvalidJsonEncodeOptions::fromJsonEncodeOptions($jsonEncodeOptions);
 
         $message = \sprintf(
             '"%s" is not valid options for json_encode().',

--- a/test/Unit/Exception/InvalidJsonEncodedTest.php
+++ b/test/Unit/Exception/InvalidJsonEncodedTest.php
@@ -18,13 +18,13 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodedException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncoded
  */
-final class InvalidJsonEncodedExceptionTest extends AbstractExceptionTestCase
+final class InvalidJsonEncodedTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\InvalidJsonEncodedException();
+        $exception = new Exception\InvalidJsonEncoded();
 
         self::assertSame('', $exception->encoded());
     }
@@ -33,7 +33,7 @@ final class InvalidJsonEncodedExceptionTest extends AbstractExceptionTestCase
     {
         $encoded = self::faker()->sentence();
 
-        $exception = Exception\InvalidJsonEncodedException::fromEncoded($encoded);
+        $exception = Exception\InvalidJsonEncoded::fromEncoded($encoded);
 
         $message = \sprintf(
             '"%s" is not valid JSON.',

--- a/test/Unit/Exception/InvalidNewLineStringTest.php
+++ b/test/Unit/Exception/InvalidNewLineStringTest.php
@@ -18,13 +18,13 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\InvalidIndentStringException
+ * @covers \Ergebnis\Json\Normalizer\Exception\InvalidNewLineString
  */
-final class InvalidIndentStringExceptionTest extends AbstractExceptionTestCase
+final class InvalidNewLineStringTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\InvalidIndentStringException();
+        $exception = new Exception\InvalidNewLineString();
 
         self::assertSame('', $exception->string());
     }
@@ -33,10 +33,10 @@ final class InvalidIndentStringExceptionTest extends AbstractExceptionTestCase
     {
         $string = self::faker()->word();
 
-        $exception = Exception\InvalidIndentStringException::fromString($string);
+        $exception = Exception\InvalidNewLineString::fromString($string);
 
         $message = \sprintf(
-            '"%s" is not a valid indent string',
+            '"%s" is not a valid new-line character sequence.',
             $string,
         );
 

--- a/test/Unit/Exception/NormalizedInvalidAccordingToSchemaTest.php
+++ b/test/Unit/Exception/NormalizedInvalidAccordingToSchemaTest.php
@@ -18,19 +18,19 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException
+ * @covers \Ergebnis\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchema
  */
-final class OriginalInvalidAccordingToSchemaExceptionTest extends AbstractExceptionTestCase
+final class NormalizedInvalidAccordingToSchemaTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\OriginalInvalidAccordingToSchemaException();
+        $exception = new Exception\NormalizedInvalidAccordingToSchema();
 
-        self::assertSame([], $exception->errors());
         self::assertSame('', $exception->schemaUri());
+        self::assertSame([], $exception->errors());
     }
 
-    public function testFromSchemaUriAndErrorsReturnsOriginalInvalidAccordingToSchemaException(): void
+    public function testFromSchemaUriReturnsNormalizedInvalidAccordingToSchemaException(): void
     {
         $faker = self::faker();
 
@@ -42,13 +42,13 @@ final class OriginalInvalidAccordingToSchemaExceptionTest extends AbstractExcept
             $faker->sentence(),
         ];
 
-        $exception = Exception\OriginalInvalidAccordingToSchemaException::fromSchemaUriAndErrors(
+        $exception = Exception\NormalizedInvalidAccordingToSchema::fromSchemaUriAndErrors(
             $schemaUri,
             ...$errors,
         );
 
         $message = \sprintf(
-            'Original JSON is not valid according to schema "%s".',
+            'Normalized JSON is not valid according to schema "%s".',
             $schemaUri,
         );
 

--- a/test/Unit/Exception/OriginalInvalidAccordingToSchemaTest.php
+++ b/test/Unit/Exception/OriginalInvalidAccordingToSchemaTest.php
@@ -18,19 +18,19 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException
+ * @covers \Ergebnis\Json\Normalizer\Exception\OriginalInvalidAccordingToSchema
  */
-final class NormalizedInvalidAccordingToSchemaExceptionTest extends AbstractExceptionTestCase
+final class OriginalInvalidAccordingToSchemaTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\NormalizedInvalidAccordingToSchemaException();
+        $exception = new Exception\OriginalInvalidAccordingToSchema();
 
-        self::assertSame('', $exception->schemaUri());
         self::assertSame([], $exception->errors());
+        self::assertSame('', $exception->schemaUri());
     }
 
-    public function testFromSchemaUriReturnsNormalizedInvalidAccordingToSchemaException(): void
+    public function testFromSchemaUriAndErrorsReturnsOriginalInvalidAccordingToSchemaException(): void
     {
         $faker = self::faker();
 
@@ -42,13 +42,13 @@ final class NormalizedInvalidAccordingToSchemaExceptionTest extends AbstractExce
             $faker->sentence(),
         ];
 
-        $exception = Exception\NormalizedInvalidAccordingToSchemaException::fromSchemaUriAndErrors(
+        $exception = Exception\OriginalInvalidAccordingToSchema::fromSchemaUriAndErrors(
             $schemaUri,
             ...$errors,
         );
 
         $message = \sprintf(
-            'Normalized JSON is not valid according to schema "%s".',
+            'Original JSON is not valid according to schema "%s".',
             $schemaUri,
         );
 

--- a/test/Unit/Exception/SchemaUriCouldNotBeReadTest.php
+++ b/test/Unit/Exception/SchemaUriCouldNotBeReadTest.php
@@ -18,25 +18,25 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeRead
  */
-final class SchemaUriCouldNotBeResolvedExceptionTest extends AbstractExceptionTestCase
+final class SchemaUriCouldNotBeReadTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\SchemaUriCouldNotBeResolvedException();
+        $exception = new Exception\SchemaUriCouldNotBeRead();
 
         self::assertSame('', $exception->schemaUri());
     }
 
-    public function testFromSchemaUriReturnsSchemaUriCouldNotBeResolvedException(): void
+    public function testFromSchemaUriReturnsSchemaUriCouldNotBeReadException(): void
     {
         $schemaUri = self::faker()->url();
 
-        $exception = Exception\SchemaUriCouldNotBeResolvedException::fromSchemaUri($schemaUri);
+        $exception = Exception\SchemaUriCouldNotBeRead::fromSchemaUri($schemaUri);
 
         $message = \sprintf(
-            'Schema URI "%s" could not be resolved.',
+            'Schema URI "%s" does not reference a document that could be read.',
             $schemaUri,
         );
 

--- a/test/Unit/Exception/SchemaUriCouldNotBeResolvedTest.php
+++ b/test/Unit/Exception/SchemaUriCouldNotBeResolvedTest.php
@@ -18,25 +18,25 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolved
  */
-final class SchemaUriReferencesInvalidJsonDocumentExceptionTest extends AbstractExceptionTestCase
+final class SchemaUriCouldNotBeResolvedTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\SchemaUriReferencesInvalidJsonDocumentException();
+        $exception = new Exception\SchemaUriCouldNotBeResolved();
 
         self::assertSame('', $exception->schemaUri());
     }
 
-    public function testFromSchemaUriReturnsSchemaUriReferencesDocumentWithInvalidMediaType(): void
+    public function testFromSchemaUriReturnsSchemaUriCouldNotBeResolvedException(): void
     {
         $schemaUri = self::faker()->url();
 
-        $exception = Exception\SchemaUriReferencesInvalidJsonDocumentException::fromSchemaUri($schemaUri);
+        $exception = Exception\SchemaUriCouldNotBeResolved::fromSchemaUri($schemaUri);
 
         $message = \sprintf(
-            'Schema URI "%s" does not reference a document with valid JSON syntax.',
+            'Schema URI "%s" could not be resolved.',
             $schemaUri,
         );
 

--- a/test/Unit/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeTest.php
+++ b/test/Unit/Exception/SchemaUriReferencesDocumentWithInvalidMediaTypeTest.php
@@ -18,25 +18,25 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaType
  */
-final class SchemaUriCouldNotBeReadExceptionTest extends AbstractExceptionTestCase
+final class SchemaUriReferencesDocumentWithInvalidMediaTypeTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\SchemaUriCouldNotBeReadException();
+        $exception = new Exception\SchemaUriReferencesDocumentWithInvalidMediaType();
 
         self::assertSame('', $exception->schemaUri());
     }
 
-    public function testFromSchemaUriReturnsSchemaUriCouldNotBeReadException(): void
+    public function testFromSchemaUriReturnsSchemaUriReferencesDocumentWithInvalidMediaType(): void
     {
         $schemaUri = self::faker()->url();
 
-        $exception = Exception\SchemaUriCouldNotBeReadException::fromSchemaUri($schemaUri);
+        $exception = Exception\SchemaUriReferencesDocumentWithInvalidMediaType::fromSchemaUri($schemaUri);
 
         $message = \sprintf(
-            'Schema URI "%s" does not reference a document that could be read.',
+            'Schema URI "%s" does not reference a document with media type "application/schema+json".',
             $schemaUri,
         );
 

--- a/test/Unit/Exception/SchemaUriReferencesInvalidJsonDocumentTest.php
+++ b/test/Unit/Exception/SchemaUriReferencesInvalidJsonDocumentTest.php
@@ -18,13 +18,13 @@ use Ergebnis\Json\Normalizer\Exception;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
+ * @covers \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocument
  */
-final class SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest extends AbstractExceptionTestCase
+final class SchemaUriReferencesInvalidJsonDocumentTest extends AbstractExceptionTestCase
 {
     public function testDefaults(): void
     {
-        $exception = new Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException();
+        $exception = new Exception\SchemaUriReferencesInvalidJsonDocument();
 
         self::assertSame('', $exception->schemaUri());
     }
@@ -33,10 +33,10 @@ final class SchemaUriReferencesDocumentWithInvalidMediaTypeExceptionTest extends
     {
         $schemaUri = self::faker()->url();
 
-        $exception = Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException::fromSchemaUri($schemaUri);
+        $exception = Exception\SchemaUriReferencesInvalidJsonDocument::fromSchemaUri($schemaUri);
 
         $message = \sprintf(
-            'Schema URI "%s" does not reference a document with media type "application/schema+json".',
+            'Schema URI "%s" does not reference a document with valid JSON syntax.',
             $schemaUri,
         );
 

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -24,9 +24,9 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\Json\Normalizer\Format\Indent
  *
- * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentSizeException
- * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentStringException
- * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentStyleException
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentSize
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentString
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidIndentStyle
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class IndentTest extends Framework\TestCase
@@ -50,7 +50,7 @@ final class IndentTest extends Framework\TestCase
     {
         $style = self::faker()->randomElement(\array_keys(Format\Indent::CHARACTERS));
 
-        $this->expectException(Exception\InvalidIndentSizeException::class);
+        $this->expectException(Exception\InvalidIndentSize::class);
 
         Format\Indent::fromSizeAndStyle(
             $size,
@@ -83,7 +83,7 @@ final class IndentTest extends Framework\TestCase
         $size = $faker->numberBetween(1);
         $style = $faker->sentence();
 
-        $this->expectException(Exception\InvalidIndentStyleException::class);
+        $this->expectException(Exception\InvalidIndentStyle::class);
 
         Format\Indent::fromSizeAndStyle(
             $size,
@@ -133,7 +133,7 @@ final class IndentTest extends Framework\TestCase
      */
     public function testFromStringRejectsInvalidIndentString(string $string): void
     {
-        $this->expectException(Exception\InvalidIndentStringException::class);
+        $this->expectException(Exception\InvalidIndentString::class);
 
         Format\Indent::fromString($string);
     }

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  *
- * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptionsException
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodeOptions
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class JsonEncodeOptionsTest extends Framework\TestCase
@@ -36,7 +36,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
      */
     public function testFromIntRejectsInvalidValue(int $value): void
     {
-        $this->expectException(Exception\InvalidJsonEncodeOptionsException::class);
+        $this->expectException(Exception\InvalidJsonEncodeOptions::class);
 
         Format\JsonEncodeOptions::fromInt($value);
     }

--- a/test/Unit/Format/NewLineTest.php
+++ b/test/Unit/Format/NewLineTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\Json\Normalizer\Format\NewLine
  *
- * @uses \Ergebnis\Json\Normalizer\Exception\InvalidNewLineStringException
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidNewLineString
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class NewLineTest extends Framework\TestCase
@@ -33,7 +33,7 @@ final class NewLineTest extends Framework\TestCase
      */
     public function testFromStringRejectsInvalidNewLineString(string $string): void
     {
-        $this->expectException(Exception\InvalidNewLineStringException::class);
+        $this->expectException(Exception\InvalidNewLineString::class);
 
         Format\NewLine::fromString($string);
     }

--- a/test/Unit/JsonTest.php
+++ b/test/Unit/JsonTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\Json\Normalizer\Json
  *
- * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncodedException
+ * @uses \Ergebnis\Json\Normalizer\Exception\InvalidJsonEncoded
  */
 final class JsonTest extends Framework\TestCase
 {
@@ -33,7 +33,7 @@ final class JsonTest extends Framework\TestCase
     {
         $string = self::faker()->realText();
 
-        $this->expectException(Exception\InvalidJsonEncodedException::class);
+        $this->expectException(Exception\InvalidJsonEncoded::class);
 
         Json::fromEncoded($string);
     }

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -28,12 +28,12 @@ use JsonSchema\SchemaStorage;
  *
  * @covers \Ergebnis\Json\Normalizer\SchemaNormalizer
  *
- * @uses \Ergebnis\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchemaException
- * @uses \Ergebnis\Json\Normalizer\Exception\OriginalInvalidAccordingToSchemaException
- * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeReadException
- * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolvedException
- * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException
- * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocumentException
+ * @uses \Ergebnis\Json\Normalizer\Exception\NormalizedInvalidAccordingToSchema
+ * @uses \Ergebnis\Json\Normalizer\Exception\OriginalInvalidAccordingToSchema
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeRead
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolved
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaType
+ * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocument
  * @uses \Ergebnis\Json\Normalizer\Json
  */
 final class SchemaNormalizerTest extends AbstractNormalizerTestCase
@@ -65,7 +65,7 @@ JSON
             new SchemaValidator\SchemaValidator(),
         );
 
-        $this->expectException(Exception\SchemaUriCouldNotBeResolvedException::class);
+        $this->expectException(Exception\SchemaUriCouldNotBeResolved::class);
 
         $normalizer->normalize($json);
     }
@@ -97,7 +97,7 @@ JSON
             new SchemaValidator\SchemaValidator(),
         );
 
-        $this->expectException(Exception\SchemaUriCouldNotBeReadException::class);
+        $this->expectException(Exception\SchemaUriCouldNotBeRead::class);
 
         $normalizer->normalize($json);
     }
@@ -129,7 +129,7 @@ JSON
             new SchemaValidator\SchemaValidator(),
         );
 
-        $this->expectException(Exception\SchemaUriReferencesDocumentWithInvalidMediaTypeException::class);
+        $this->expectException(Exception\SchemaUriReferencesDocumentWithInvalidMediaType::class);
 
         $normalizer->normalize($json);
     }
@@ -161,7 +161,7 @@ JSON
             new SchemaValidator\SchemaValidator(),
         );
 
-        $this->expectException(Exception\SchemaUriReferencesInvalidJsonDocumentException::class);
+        $this->expectException(Exception\SchemaUriReferencesInvalidJsonDocument::class);
 
         $normalizer->normalize($json);
     }
@@ -203,7 +203,7 @@ JSON;
             new SchemaValidator\SchemaValidator(),
         );
 
-        $this->expectException(Exception\OriginalInvalidAccordingToSchemaException::class);
+        $this->expectException(Exception\OriginalInvalidAccordingToSchema::class);
 
         $normalizer->normalize($json);
     }


### PR DESCRIPTION
This pull request

- [x] drops the `Exception` suffix from all exceptions