### PR TITLE
Fix: Rename interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`2.2.0...3.0.0`][2.2.0...3.0.0].
 - Required `ergebnis/json-schema-validator:^3.0.0` ([#666]), by [@dependabot]
 - Renamed `Exception\ExceptionInterface` to `Exception\Exception` ([#667]), by [@dependabot]
 - Removed `Exception` suffix from all exceptions ([#668]), by [@dependabot]
+- Renamed `NormalizerInterface` to `Nornmalizer` ([#669]), by [@dependabot]
 
 ## [`2.2.0`][2.2.0]
 
@@ -491,6 +492,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#666]: https://github.com/ergebnis/json-normalizer/pull/666
 [#667]: https://github.com/ergebnis/json-normalizer/pull/667
 [#668]: https://github.com/ergebnis/json-normalizer/pull/668
+[#669]: https://github.com/ergebnis/json-normalizer/pull/669
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ JSON;
 
 $json = Normalizer\Json::fromEncoded($encoded);
 
-/* @var Normalizer\NormalizerInterface $composedNormalizer */
+/* @var Normalizer\Normalizer $composedNormalizer */
 $normalizer = new Normalizer\AutoFormatNormalizer(
     $composedNormalizer,
     new Normalizer\Format\Formatter(new Printer\Printer())
@@ -179,7 +179,7 @@ JSON;
 
 $json = Normalizer\Json::fromEncoded($encoded);
 
-/* @var Normalizer\NormalizerInterface $composedNormalizer */
+/* @var Normalizer\Normalizer $composedNormalizer */
 /* @var Normalizer\Format\Format $format */
 $normalizer = new Normalizer\FixedFormatNormalizer(
     $composedNormalizer,

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -154,8 +154,8 @@
   </file>
   <file src="test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php">
     <MixedInferredReturnType occurrences="2">
-      <code>NormalizerInterface</code>
-      <code>NormalizerInterface[]</code>
+      <code>Normalizer</code>
+      <code>Normalizer[]</code>
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="2">
       <code>$property-&gt;getValue($normalizer)</code>

--- a/src/AutoFormatNormalizer.php
+++ b/src/AutoFormatNormalizer.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-final class AutoFormatNormalizer implements NormalizerInterface
+final class AutoFormatNormalizer implements Normalizer
 {
-    private NormalizerInterface $normalizer;
+    private Normalizer $normalizer;
     private Format\FormatterInterface $formatter;
 
     public function __construct(
-        NormalizerInterface $normalizer,
+        Normalizer $normalizer,
         Format\FormatterInterface $formatter
     ) {
         $this->normalizer = $normalizer;

--- a/src/CallableNormalizer.php
+++ b/src/CallableNormalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-final class CallableNormalizer implements NormalizerInterface
+final class CallableNormalizer implements Normalizer
 {
     /**
      * @var callable

--- a/src/ChainNormalizer.php
+++ b/src/ChainNormalizer.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-final class ChainNormalizer implements NormalizerInterface
+final class ChainNormalizer implements Normalizer
 {
     /**
-     * @phpstan-var list<NormalizerInterface>
-     * @psalm-var list<NormalizerInterface>
+     * @phpstan-var list<Normalizer>
+     * @psalm-var list<Normalizer>
      *
-     * @var array<int, NormalizerInterface>
+     * @var array<int, Normalizer>
      */
     private array $normalizers;
 
-    public function __construct(NormalizerInterface ...$normalizers)
+    public function __construct(Normalizer ...$normalizers)
     {
         $this->normalizers = \array_values($normalizers);
     }
@@ -32,7 +32,7 @@ final class ChainNormalizer implements NormalizerInterface
     {
         return \array_reduce(
             $this->normalizers,
-            static function (Json $json, NormalizerInterface $normalizer): Json {
+            static function (Json $json, Normalizer $normalizer): Json {
                 return $normalizer->normalize($json);
             },
             $json,

--- a/src/FixedFormatNormalizer.php
+++ b/src/FixedFormatNormalizer.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-final class FixedFormatNormalizer implements NormalizerInterface
+final class FixedFormatNormalizer implements Normalizer
 {
-    private NormalizerInterface $normalizer;
+    private Normalizer $normalizer;
     private Format\Format $format;
     private Format\FormatterInterface $formatter;
 
     public function __construct(
-        NormalizerInterface $normalizer,
+        Normalizer $normalizer,
         Format\Format $format,
         Format\FormatterInterface $formatter
     ) {

--- a/src/IndentNormalizer.php
+++ b/src/IndentNormalizer.php
@@ -15,7 +15,7 @@ namespace Ergebnis\Json\Normalizer;
 
 use Ergebnis\Json\Printer;
 
-final class IndentNormalizer implements NormalizerInterface
+final class IndentNormalizer implements Normalizer
 {
     private Format\Indent $indent;
     private Printer\PrinterInterface $printer;

--- a/src/JsonEncodeNormalizer.php
+++ b/src/JsonEncodeNormalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-final class JsonEncodeNormalizer implements NormalizerInterface
+final class JsonEncodeNormalizer implements Normalizer
 {
     private Format\JsonEncodeOptions $jsonEncodeOptions;
 

--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-interface NormalizerInterface
+interface Normalizer
 {
     /**
      * @throws Exception\SchemaUriCouldNotBeResolved

--- a/src/SchemaNormalizer.php
+++ b/src/SchemaNormalizer.php
@@ -21,7 +21,7 @@ use JsonSchema\Exception\ResourceNotFoundException;
 use JsonSchema\Exception\UriResolverException;
 use JsonSchema\SchemaStorage;
 
-final class SchemaNormalizer implements NormalizerInterface
+final class SchemaNormalizer implements Normalizer
 {
     private string $schemaUri;
     private SchemaStorage $schemaStorage;

--- a/src/Vendor/Composer/BinNormalizer.php
+++ b/src/Vendor/Composer/BinNormalizer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Vendor\Composer;
 
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 
-final class BinNormalizer implements NormalizerInterface
+final class BinNormalizer implements Normalizer
 {
     public function normalize(Json $json): Json
     {

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -17,9 +17,9 @@ use Ergebnis\Json\Normalizer;
 use Ergebnis\Json\SchemaValidator;
 use JsonSchema\SchemaStorage;
 
-final class ComposerJsonNormalizer implements Normalizer\NormalizerInterface
+final class ComposerJsonNormalizer implements Normalizer\Normalizer
 {
-    private Normalizer\NormalizerInterface $normalizer;
+    private Normalizer\Normalizer $normalizer;
 
     public function __construct(string $schemaUri)
     {

--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Vendor\Composer;
 
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 
-final class ConfigHashNormalizer implements NormalizerInterface
+final class ConfigHashNormalizer implements Normalizer
 {
     private const PROPERTIES_THAT_SHOULD_BE_SORTED = [
         'config',

--- a/src/Vendor/Composer/PackageHashNormalizer.php
+++ b/src/Vendor/Composer/PackageHashNormalizer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Vendor\Composer;
 
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 
-final class PackageHashNormalizer implements NormalizerInterface
+final class PackageHashNormalizer implements Normalizer
 {
     /**
      * @see https://github.com/composer/composer/blob/2.0.11/src/Composer/Repository/PlatformRepository.php#L33

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Vendor\Composer;
 
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 
-final class VersionConstraintNormalizer implements NormalizerInterface
+final class VersionConstraintNormalizer implements Normalizer
 {
     private const PROPERTIES_THAT_SHOULD_BE_NORMALIZED = [
         'conflict',

--- a/src/WithFinalNewLineNormalizer.php
+++ b/src/WithFinalNewLineNormalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-final class WithFinalNewLineNormalizer implements NormalizerInterface
+final class WithFinalNewLineNormalizer implements Normalizer
 {
     public function normalize(Json $json): Json
     {

--- a/src/WithoutFinalNewLineNormalizer.php
+++ b/src/WithoutFinalNewLineNormalizer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Json\Normalizer;
 
-final class WithoutFinalNewLineNormalizer implements NormalizerInterface
+final class WithoutFinalNewLineNormalizer implements Normalizer
 {
     public function normalize(Json $json): Json
     {

--- a/test/Unit/AutoFormatNormalizerTest.php
+++ b/test/Unit/AutoFormatNormalizerTest.php
@@ -16,7 +16,7 @@ namespace Ergebnis\Json\Normalizer\Test\Unit;
 use Ergebnis\Json\Normalizer\AutoFormatNormalizer;
 use Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 
 /**
  * @internal
@@ -57,7 +57,7 @@ JSON
 JSON
         );
 
-        $composedNormalizer = $this->createMock(NormalizerInterface::class);
+        $composedNormalizer = $this->createMock(Normalizer::class);
 
         $composedNormalizer
             ->expects(self::once())

--- a/test/Unit/ChainNormalizerTest.php
+++ b/test/Unit/ChainNormalizerTest.php
@@ -15,7 +15,7 @@ namespace Ergebnis\Json\Normalizer\Test\Unit;
 
 use Ergebnis\Json\Normalizer\ChainNormalizer;
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 
 /**
  * @internal
@@ -48,14 +48,14 @@ JSON
 
         $last = \end($results);
 
-        $normalizers = \array_map(function ($result) use ($json): NormalizerInterface {
+        $normalizers = \array_map(function ($result) use ($json): Normalizer {
             static $previous = null;
 
             if (null === $previous) {
                 $previous = $json;
             }
 
-            $normalizer = $this->createMock(NormalizerInterface::class);
+            $normalizer = $this->createMock(Normalizer::class);
 
             $normalizer
                 ->expects(self::once())

--- a/test/Unit/FixedFormatNormalizerTest.php
+++ b/test/Unit/FixedFormatNormalizerTest.php
@@ -16,7 +16,7 @@ namespace Ergebnis\Json\Normalizer\Test\Unit;
 use Ergebnis\Json\Normalizer\FixedFormatNormalizer;
 use Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 
 /**
  * @internal
@@ -66,7 +66,7 @@ JSON
 JSON
         );
 
-        $composedNormalizer = $this->createMock(NormalizerInterface::class);
+        $composedNormalizer = $this->createMock(Normalizer::class);
 
         $composedNormalizer
             ->expects(self::once())

--- a/test/Unit/Vendor/Composer/AbstractComposerTestCase.php
+++ b/test/Unit/Vendor/Composer/AbstractComposerTestCase.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Test\Unit\Vendor\Composer;
 
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 use Ergebnis\Json\Normalizer\Test;
 
 /**
@@ -34,7 +34,7 @@ abstract class AbstractComposerTestCase extends Test\Unit\AbstractNormalizerTest
 
         $reflection = new \ReflectionClass($className);
 
-        /** @var NormalizerInterface $normalizer */
+        /** @var Normalizer $normalizer */
         $normalizer = $reflection->newInstanceWithoutConstructor();
 
         $normalized = $normalizer->normalize($json);

--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -15,7 +15,7 @@ namespace Ergebnis\Json\Normalizer\Test\Unit\Vendor\Composer;
 
 use Ergebnis\Json\Normalizer\ChainNormalizer;
 use Ergebnis\Json\Normalizer\Json;
-use Ergebnis\Json\Normalizer\NormalizerInterface;
+use Ergebnis\Json\Normalizer\Normalizer;
 use Ergebnis\Json\Normalizer\SchemaNormalizer;
 use Ergebnis\Json\Normalizer\Vendor;
 
@@ -220,7 +220,7 @@ JSON
      */
     private static function assertComposesNormalizer(
         string $className,
-        NormalizerInterface $normalizer
+        Normalizer $normalizer
     ): void {
         $attributeName = 'normalizer';
 
@@ -244,7 +244,7 @@ JSON
      */
     private static function assertComposesNormalizers(
         array $classNames,
-        NormalizerInterface $normalizer
+        Normalizer $normalizer
     ): void {
         $attributeName = 'normalizers';
 
@@ -266,7 +266,7 @@ JSON
         );
     }
 
-    private static function composedNormalizer(NormalizerInterface $normalizer): NormalizerInterface
+    private static function composedNormalizer(Normalizer $normalizer): Normalizer
     {
         $reflection = new \ReflectionObject($normalizer);
 
@@ -278,11 +278,11 @@ JSON
     }
 
     /**
-     * @throws \ReflectionException
+     *@throws \ReflectionException
      *
-     * @return NormalizerInterface[]
+     * @return Normalizer[]
      */
-    private static function composedNormalizers(NormalizerInterface $normalizer): array
+    private static function composedNormalizers(Normalizer $normalizer): array
     {
         $reflection = new \ReflectionObject($normalizer);
 


### PR DESCRIPTION
This pull request

- [x] renames `NormalizerInterface` to `Normalizer`