### PR TITLE
Fix: Rename class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`2.2.0...3.0.0`][2.2.0...3.0.0].
 - Renamed `Exception\ExceptionInterface` to `Exception\Exception` ([#667]), by [@dependabot]
 - Removed `Exception` suffix from all exceptions ([#668]), by [@dependabot]
 - Renamed `NormalizerInterface` to `Normalizer` ([#669]), by [@dependabot]
+- Renamed `Format\Formatter` to `Format\DefaultFormatter` ([#672]), by [@dependabot]
 
 ## [`2.2.0`][2.2.0]
 
@@ -493,6 +494,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#667]: https://github.com/ergebnis/json-normalizer/pull/667
 [#668]: https://github.com/ergebnis/json-normalizer/pull/668
 [#669]: https://github.com/ergebnis/json-normalizer/pull/669
+[#672]: https://github.com/ergebnis/json-normalizer/pull/672
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $json = Normalizer\Json::fromEncoded($encoded);
 /* @var Normalizer\Normalizer $composedNormalizer */
 $normalizer = new Normalizer\AutoFormatNormalizer(
     $composedNormalizer,
-    new Normalizer\Format\Formatter(new Printer\Printer())
+    new Normalizer\Format\DefaultFormatter(new Printer\Printer())
 );
 
 $normalized = $normalizer->normalize($json);
@@ -184,7 +184,7 @@ $json = Normalizer\Json::fromEncoded($encoded);
 $normalizer = new Normalizer\FixedFormatNormalizer(
     $composedNormalizer,
     $format,
-    new Normalizer\Format\Formatter(new Printer\Printer())
+    new Normalizer\Format\DefaultFormatter(new Printer\Printer())
 );
 
 $normalized = $normalizer->normalize($json);

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -63,20 +63,20 @@
       <code>$value</code>
     </UnusedForeachValue>
   </file>
-  <file src="test/Unit/Format/FormatTest.php">
-    <MixedInferredReturnType occurrences="3">
-      <code>\Generator&lt;array&lt;string&gt;&gt;</code>
-      <code>\Generator&lt;array&lt;string&gt;&gt;</code>
-      <code>\Generator&lt;array&lt;string&gt;&gt;</code>
-    </MixedInferredReturnType>
-  </file>
-  <file src="test/Unit/Format/FormatterTest.php">
+  <file src="test/Unit/Format/DefaultFormatterTest.php">
     <MixedArgument occurrences="1">
       <code>$newLineString</code>
     </MixedArgument>
     <MixedAssignment occurrences="1">
       <code>$newLineString</code>
     </MixedAssignment>
+  </file>
+  <file src="test/Unit/Format/FormatTest.php">
+    <MixedInferredReturnType occurrences="3">
+      <code>\Generator&lt;array&lt;string&gt;&gt;</code>
+      <code>\Generator&lt;array&lt;string&gt;&gt;</code>
+      <code>\Generator&lt;array&lt;string&gt;&gt;</code>
+    </MixedInferredReturnType>
   </file>
   <file src="test/Unit/Format/IndentTest.php">
     <MixedArgument occurrences="1">

--- a/src/Format/DefaultFormatter.php
+++ b/src/Format/DefaultFormatter.php
@@ -16,7 +16,7 @@ namespace Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Printer;
 
-final class Formatter implements FormatterInterface
+final class DefaultFormatter implements FormatterInterface
 {
     private Printer\PrinterInterface $printer;
 

--- a/test/Unit/Format/DefaultFormatterTest.php
+++ b/test/Unit/Format/DefaultFormatterTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework;
 /**
  * @internal
  *
- * @covers \Ergebnis\Json\Normalizer\Format\Formatter
+ * @covers \Ergebnis\Json\Normalizer\Format\DefaultFormatter
  *
  * @uses \Ergebnis\Json\Normalizer\Format\Format
  * @uses \Ergebnis\Json\Normalizer\Format\Indent
@@ -30,7 +30,7 @@ use PHPUnit\Framework;
  * @uses \Ergebnis\Json\Normalizer\Format\NewLine
  * @uses \Ergebnis\Json\Normalizer\Json
  */
-final class FormatterTest extends Framework\TestCase
+final class DefaultFormatterTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
@@ -92,7 +92,7 @@ JSON;
             )
             ->willReturn($printedWithIndentAndNewLine);
 
-        $formatter = new Format\Formatter($printer);
+        $formatter = new Format\DefaultFormatter($printer);
 
         $formatted = $formatter->format(
             $json,


### PR DESCRIPTION
This pull request

- [x] renames `Format\Formatter` to `Format\DefaultFormatter`