### PR TITLE
Fix: Rename interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a full diff see [`2.2.0...3.0.0`][2.2.0...3.0.0].
 - Removed `Exception` suffix from all exceptions ([#668]), by [@dependabot]
 - Renamed `NormalizerInterface` to `Normalizer` ([#669]), by [@dependabot]
 - Renamed `Format\Formatter` to `Format\DefaultFormatter` ([#672]), by [@dependabot]
+- Renamed `Format\FormatterInterface` to `Format\Formatter` ([#673]), by [@dependabot]
 
 ## [`2.2.0`][2.2.0]
 
@@ -495,6 +496,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#668]: https://github.com/ergebnis/json-normalizer/pull/668
 [#669]: https://github.com/ergebnis/json-normalizer/pull/669
 [#672]: https://github.com/ergebnis/json-normalizer/pull/672
+[#673]: https://github.com/ergebnis/json-normalizer/pull/673
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/AutoFormatNormalizer.php
+++ b/src/AutoFormatNormalizer.php
@@ -16,11 +16,11 @@ namespace Ergebnis\Json\Normalizer;
 final class AutoFormatNormalizer implements Normalizer
 {
     private Normalizer $normalizer;
-    private Format\FormatterInterface $formatter;
+    private Format\Formatter $formatter;
 
     public function __construct(
         Normalizer $normalizer,
-        Format\FormatterInterface $formatter
+        Format\Formatter $formatter
     ) {
         $this->normalizer = $normalizer;
         $this->formatter = $formatter;

--- a/src/FixedFormatNormalizer.php
+++ b/src/FixedFormatNormalizer.php
@@ -17,12 +17,12 @@ final class FixedFormatNormalizer implements Normalizer
 {
     private Normalizer $normalizer;
     private Format\Format $format;
-    private Format\FormatterInterface $formatter;
+    private Format\Formatter $formatter;
 
     public function __construct(
         Normalizer $normalizer,
         Format\Format $format,
-        Format\FormatterInterface $formatter
+        Format\Formatter $formatter
     ) {
         $this->normalizer = $normalizer;
         $this->format = $format;

--- a/src/Format/DefaultFormatter.php
+++ b/src/Format/DefaultFormatter.php
@@ -16,7 +16,7 @@ namespace Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Json;
 use Ergebnis\Json\Printer;
 
-final class DefaultFormatter implements FormatterInterface
+final class DefaultFormatter implements Formatter
 {
     private Printer\PrinterInterface $printer;
 

--- a/src/Format/Formatter.php
+++ b/src/Format/Formatter.php
@@ -15,7 +15,7 @@ namespace Ergebnis\Json\Normalizer\Format;
 
 use Ergebnis\Json\Normalizer\Json;
 
-interface FormatterInterface
+interface Formatter
 {
     public function format(
         Json $json,

--- a/test/Unit/AutoFormatNormalizerTest.php
+++ b/test/Unit/AutoFormatNormalizerTest.php
@@ -65,7 +65,7 @@ JSON
             ->with(self::identicalTo($json))
             ->willReturn($normalized);
 
-        $formatter = $this->createMock(Format\FormatterInterface::class);
+        $formatter = $this->createMock(Format\Formatter::class);
 
         $formatter
             ->expects(self::once())

--- a/test/Unit/FixedFormatNormalizerTest.php
+++ b/test/Unit/FixedFormatNormalizerTest.php
@@ -74,7 +74,7 @@ JSON
             ->with(self::identicalTo($json))
             ->willReturn($normalized);
 
-        $formatter = $this->createMock(Format\FormatterInterface::class);
+        $formatter = $this->createMock(Format\Formatter::class);
 
         $formatter
             ->expects(self::once())


### PR DESCRIPTION
This pull request

- [x] renames `Format\FormatterInterface` to `Format\Formatter`