### PR TITLE
Sort `allow-plugins` and `preferred-install` properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`3.0.0...main`][3.0.0...main].
+For a full diff see [`3.0.1...main`][3.0.1...main].
+
+## [`3.0.1`][3.0.1]
+
+For a full diff see [`3.0.0...3.0.1`][3.0.0...3.0.1].
+
+### Fixed
+
+- Adjusted `ConfigHashNormalizer` to sort keys correctly ([#723]), by [@fredded]
 
 ### Changed
 
@@ -385,6 +393,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [2.1.0]: https://github.com/ergebnis/json-normalizer/releases/tag/2.1.0
 [2.2.0]: https://github.com/ergebnis/json-normalizer/releases/tag/2.2.0
 [3.0.0]: https://github.com/ergebnis/json-normalizer/releases/tag/3.0.0
+[3.0.1]: https://github.com/ergebnis/json-normalizer/releases/tag/3.0.1
 
 [5d8b3e2...0.1.0]: https://github.com/ergebnis/json-normalizer/compare/5d8b3e2...0.1.0
 [0.1.0...0.2.0]: https://github.com/ergebnis/json-normalizer/compare/0.1.0...0.2.0
@@ -413,7 +422,8 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [2.0.0...2.1.0]: https://github.com/ergebnis/json-normalizer/compare/2.0.0...2.1.0
 [2.1.0...2.2.0]: https://github.com/ergebnis/json-normalizer/compare/2.1.0...2.2.0
 [2.2.0...3.0.0]: https://github.com/ergebnis/json-normalizer/compare/2.2.0...3.0.0
-[3.0.0...main]: https://github.com/ergebnis/json-normalizer/compare/3.0.0...main
+[3.0.0...3.0.1]: https://github.com/ergebnis/json-normalizer/compare/3.0.0...3.0.1
+[3.0.1...main]: https://github.com/ergebnis/json-normalizer/compare/3.0.1...main
 
 [#1]: https://github.com/ergebnis/json-normalizer/pull/1
 [#2]: https://github.com/ergebnis/json-normalizer/pull/2
@@ -504,8 +514,10 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#673]: https://github.com/ergebnis/json-normalizer/pull/673
 [#697]: https://github.com/ergebnis/json-normalizer/pull/697
 [#698]: https://github.com/ergebnis/json-normalizer/pull/698
+[#723]: https://github.com/ergebnis/json-normalizer/pull/723
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot
 [@ergebnis]: https://github.com/ergebnis
+[@fredden]: https://github.com/fredden
 [@localheinz]: https://github.com/localheinz

--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -24,15 +24,6 @@ final class ConfigHashNormalizer implements Normalizer
         'scripts-descriptions',
     ];
 
-    /**
-     * @see https://getcomposer.org/doc/06-config.md#allow-plugins
-     * @see https://getcomposer.org/doc/06-config.md#preferred-install
-     */
-    private const PROPERTY_PATHS_THAT_SHOULD_NOT_BE_SORTED = [
-        'config.allow-plugins',
-        'config.preferred-install',
-    ];
-
     public function normalize(Json $json): Json
     {
         $decoded = $json->decoded();
@@ -72,10 +63,6 @@ final class ConfigHashNormalizer implements Normalizer
         string $propertyPath,
         $value
     ) {
-        if (\in_array($propertyPath, self::PROPERTY_PATHS_THAT_SHOULD_NOT_BE_SORTED, true)) {
-            return $value;
-        }
-
         if (!\is_object($value)) {
             return $value;
         }
@@ -87,7 +74,16 @@ final class ConfigHashNormalizer implements Normalizer
             return $value;
         }
 
-        \ksort($sorted);
+        // @see https://getcomposer.org/doc/06-config.md#allow-plugins
+        // @see https://getcomposer.org/doc/06-config.md#preferred-install
+        \uksort($sorted, static function (string $a, string $b) {
+            // '*' = ASCII 42 (ie, before all letters, numbers, and dash)
+            // '~' = ASCII 126 (ie, after all letters, numbers, and dash)
+            $a = \str_replace('*', '~', $a);
+            $b = \str_replace('*', '~', $b);
+
+            return \strcmp($a, $b);
+        });
 
         $names = \array_keys($sorted);
 

--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -74,15 +74,11 @@ final class ConfigHashNormalizer implements Normalizer
             return $value;
         }
 
-        // @see https://getcomposer.org/doc/06-config.md#allow-plugins
-        // @see https://getcomposer.org/doc/06-config.md#preferred-install
-        \uksort($sorted, static function (string $a, string $b) {
-            // '*' = ASCII 42 (ie, before all letters, numbers, and dash)
-            // '~' = ASCII 126 (ie, after all letters, numbers, and dash)
-            $a = \str_replace('*', '~', $a);
-            $b = \str_replace('*', '~', $b);
-
-            return \strcmp($a, $b);
+        \uksort($sorted, static function (string $a, string $b): int {
+            return \strcmp(
+                self::normalizeKey($a),
+                self::normalizeKey($b),
+            );
         });
 
         $names = \array_keys($sorted);
@@ -99,6 +95,24 @@ final class ConfigHashNormalizer implements Normalizer
                     $value,
                 );
             }, $sorted, $names),
+        );
+    }
+
+    /**
+     * Replaces characters in keys to ensure the correct order.
+     *
+     * - '*' = ASCII 42 (i.e., before all letters, numbers, and dash)
+     * - '~' = ASCII 126 (i.e., after all letters, numbers, and dash)
+     *
+     * @see https://getcomposer.org/doc/06-config.md#allow-plugins
+     * @see https://getcomposer.org/doc/06-config.md#preferred-install
+     */
+    private static function normalizeKey(string $key): string
+    {
+        return \str_replace(
+            '*',
+            '~',
+            $key,
         );
     }
 }


### PR DESCRIPTION
This pull request

- [x] Fixes the sort-order for keys where wildcards are allowed and their order matters

The Composer documentation says that more specific keys should be listed first, which this change ensures while also keeping the items in alphabetical order.

Fixes https://github.com/ergebnis/composer-normalize/issues/860
Fixes https://github.com/ergebnis/composer-normalize/issues/868
Related to https://github.com/ergebnis/json-normalizer/pull/590
Fixes https://github.com/ergebnis/composer-normalize/issues/644
Related to https://github.com/ergebnis/json-normalizer/pull/425