### PR TITLE
Fix: Adjust `ComposerJsonNormalizer` to stop sorting `scripts.auto-scripts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Required `ergebnis/json-schema-validator:^4.0.0` ([#771]), by [@localheinz]
 - Allowed configuring the `Normalizer\SchemaNormalizer` to exclude properties from being sorted ([#774]), by [@localheinz]
 
+### Fixed
+
+- Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `scripts.auto-scripts` ([#776]), by [@localheinz]
+
 ### Removed
 
 - Started using `ergebnis/json` and removed `Json` and `Exception\InvalidJsonEncoded` ([#772]), by [@localheinz]
@@ -524,6 +528,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#772]: https://github.com/ergebnis/json-normalizer/pull/772
 [#774]: https://github.com/ergebnis/json-normalizer/pull/774
 [#775]: https://github.com/ergebnis/json-normalizer/pull/775
+[#776]: https://github.com/ergebnis/json-normalizer/pull/776
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -30,7 +30,7 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                 $schemaUri,
                 new SchemaStorage(),
                 new SchemaValidator\SchemaValidator(),
-                Pointer\Specification::never(),
+                Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
             ),
             new BinNormalizer(),
             new PackageHashNormalizer(),

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Scripts/AutoScripts/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Scripts/AutoScripts/normalized.json
@@ -15,10 +15,10 @@
   ],
   "scripts": {
     "auto-scripts": {
-      "assets:install %PUBLIC_DIR%": "symfony-cmd",
-      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
       "cache:clear": "symfony-cmd",
-      "doctrine:migrations:migrate -v": "symfony-cmd"
+      "doctrine:migrations:migrate -v": "symfony-cmd",
+      "bazinga:js-translation:dump assets --merge-domains --format=json": "symfony-cmd",
+      "assets:install %PUBLIC_DIR%": "symfony-cmd"
     }
   }
 }


### PR DESCRIPTION
This pull request

- [x] stops sorting `scripts.auto-scripts` in `composer.json`

Related to https://github.com/ergebnis/composer-normalize/issues/704.