### PR TITLE
Fix: Adjust `ComposerJsonNormalizer` to stop sorting `extra.installer-paths`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 ### Fixed
 
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `scripts.auto-scripts` ([#776]), by [@localheinz]
+- Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `extra.installer-paths` ([#777]), by [@localheinz]
 
 ### Removed
 
@@ -529,6 +530,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#774]: https://github.com/ergebnis/json-normalizer/pull/774
 [#775]: https://github.com/ergebnis/json-normalizer/pull/775
 [#776]: https://github.com/ergebnis/json-normalizer/pull/776
+[#777]: https://github.com/ergebnis/json-normalizer/pull/777
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -30,7 +30,10 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                 $schemaUri,
                 new SchemaStorage(),
                 new SchemaValidator\SchemaValidator(),
-                Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
+                Pointer\Specification::anyOf(
+                    Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/extra/installer-paths')),
+                    Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
+                ),
             ),
             new BinNormalizer(),
             new PackageHashNormalizer(),

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Extra/InstallerPaths/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Extra/InstallerPaths/normalized.json
@@ -19,16 +19,16 @@
       "app/core": [
         "type:drupal-core"
       ],
+      "app/libraries/{$name}": [
+        "type:drupal-library",
+        "type:bower-asset",
+        "type:npm-asset"
+      ],
       "app/libraries/jquery.easing": [
         "bower-asset/jquery-easing-original"
       ],
       "app/libraries/slick": [
         "bower-asset/slick-carousel"
-      ],
-      "app/libraries/{$name}": [
-        "type:drupal-library",
-        "type:bower-asset",
-        "type:npm-asset"
       ],
       "app/modules/contrib/{$name}": [
         "type:drupal-module"


### PR DESCRIPTION
This pull request

- [x] adjusts `ComposerJsonNormalizer` to stop sorting `extra.installer-paths`

Related to https://github.com/ergebnis/composer-normalize/issues/704.