### PR TITLE
Fix: Adjust `ComposerJsonNormalizer` to stop sorting `config.allow-plugins`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `scripts.auto-scripts` ([#776]), by [@localheinz]
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `extra.installer-paths` ([#777]), by [@localheinz]
+- Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `config.allow-plugins` ([#778]), by [@localheinz]
 
 ### Removed
 
@@ -531,6 +532,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#775]: https://github.com/ergebnis/json-normalizer/pull/775
 [#776]: https://github.com/ergebnis/json-normalizer/pull/776
 [#777]: https://github.com/ergebnis/json-normalizer/pull/777
+[#778]: https://github.com/ergebnis/json-normalizer/pull/778
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -31,6 +31,7 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                 new SchemaStorage(),
                 new SchemaValidator\SchemaValidator(),
                 Pointer\Specification::anyOf(
+                    Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/config/allow-plugins')),
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/extra/installer-paths')),
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
                 ),

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Config/AllowPlugins/IsObject/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Config/AllowPlugins/IsObject/normalized.json
@@ -16,9 +16,9 @@
   "homepage": "https://getcomposer.org/doc/06-config.md#allow-plugins",
   "config": {
     "allow-plugins": {
-      "composer/*": false,
       "composer/package-versions-deprecated": true,
-      "infection/extension-installer": true
+      "infection/extension-installer": true,
+      "composer/*": false
     }
   }
 }


### PR DESCRIPTION
This pull request

- [x] adjusts `ComposerJsonNormalizer` to stop sorting `config.allow-plugins`

Related to https://github.com/ergebnis/composer-normalize/issues/704.