### PR TITLE
Fix: Adjust `ComposerJsonNormalizer` to stop sorting `config.preferred-install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `scripts.auto-scripts` ([#776]), by [@localheinz]
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `extra.installer-paths` ([#777]), by [@localheinz]
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `config.allow-plugins` ([#778]), by [@localheinz]
+- Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `config.preferred-install` ([#779]), by [@localheinz]
 
 ### Removed
 

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -32,6 +32,7 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                 new SchemaValidator\SchemaValidator(),
                 Pointer\Specification::anyOf(
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/config/allow-plugins')),
+                    Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/config/preferred-install')),
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/extra/installer-paths')),
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
                 ),

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Config/PreferredInstall/IsObject/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Config/PreferredInstall/IsObject/normalized.json
@@ -16,11 +16,11 @@
   "homepage": "https://getcomposer.org/doc/06-config.md#preferred-install",
   "config": {
     "preferred-install": {
-      "*": "dist",
+      "foo/something-longer-but-alphabetically-after-package-*": "source",
       "foo/*": "dist",
       "foo/package-*": "source",
       "foo/package-one": "dist",
-      "foo/something-longer-but-alphabetically-after-package-*": "source"
+      "*": "dist"
     }
   }
 }


### PR DESCRIPTION
This pull request

- [x] adjusts `ComposerJsonNormalizer` to stop sorting `config.preferred-install`

Related to https://github.com/ergebnis/composer-normalize/issues/704.