### PR TITLE
Fix: Adjust `ComposerJsonNormalizer` to stop sorting direct children of `extra.patches`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `extra.installer-paths` ([#777]), by [@localheinz]
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `config.allow-plugins` ([#778]), by [@localheinz]
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `config.preferred-install` ([#779]), by [@localheinz]
+- Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting children of `extra.patches` ([#780]), by [@localheinz]
 
 ### Removed
 
@@ -535,6 +536,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#777]: https://github.com/ergebnis/json-normalizer/pull/777
 [#778]: https://github.com/ergebnis/json-normalizer/pull/778
 [#779]: https://github.com/ergebnis/json-normalizer/pull/779
+[#780]: https://github.com/ergebnis/json-normalizer/pull/780
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -34,6 +34,9 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/config/allow-plugins')),
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/config/preferred-install')),
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/extra/installer-paths')),
+                    Pointer\Specification::closure(static function (Pointer\JsonPointer $jsonPointer): bool {
+                        return 1 === \preg_match('{^\/extra\/patches\/([^/])+$}', $jsonPointer->toJsonString());
+                    }),
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
                 ),
             ),

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Extra/Patches/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizes/Extra/Patches/normalized.json
@@ -21,8 +21,8 @@
         "baz": "https://www.drupal.org/files/issues/2019-01-01/baz.patch"
       },
       "drupal/foo": {
-        "baz": "https://www.drupal.org/files/issues/2019-01-01/baz.patch",
-        "foo": "https://www.drupal.org/files/issues/2020-12-13/foo.patch"
+        "foo": "https://www.drupal.org/files/issues/2020-12-13/foo.patch",
+        "baz": "https://www.drupal.org/files/issues/2019-01-01/baz.patch"
       }
     }
   }


### PR DESCRIPTION
This pull request

- [x] adjusts `ComposerJsonNormalizer` to stop sorting direct children of `extra.patches`

Related to https://github.com/ergebnis/composer-normalize/issues/704.

/cc @FlorentTorregrosa @rafatwork @TravisCarden
