### PR TITLE
Enhancement: Introduce named constructor for default `json_encode()` options

### DIFF
--- a/src/Format/JsonEncodeOptions.php
+++ b/src/Format/JsonEncodeOptions.php
@@ -25,6 +25,11 @@ final class JsonEncodeOptions
     {
     }
 
+    public static function default(): self
+    {
+        return new self(0);
+    }
+
     /**
      * @throws Exception\InvalidJsonEncodeOptions
      */

--- a/src/SchemaNormalizer.php
+++ b/src/SchemaNormalizer.php
@@ -61,11 +61,14 @@ final class SchemaNormalizer implements Normalizer
             );
         }
 
-        $normalized = Json::fromString(\json_encode($this->normalizeData(
-            $json->decoded(),
-            $schema,
-            Pointer\JsonPointer::document(),
-        )));
+        $normalized = Json::fromString(\json_encode(
+            $this->normalizeData(
+                $json->decoded(),
+                $schema,
+                Pointer\JsonPointer::document(),
+            ),
+            Format\JsonEncodeOptions::default()->toInt(),
+        ));
 
         $resultAfterNormalization = $this->schemaValidator->validate(
             $normalized,

--- a/src/Vendor/Composer/BinNormalizer.php
+++ b/src/Vendor/Composer/BinNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Vendor\Composer;
 
 use Ergebnis\Json\Json;
+use Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Normalizer;
 
 final class BinNormalizer implements Normalizer
@@ -37,7 +38,10 @@ final class BinNormalizer implements Normalizer
         $decoded->bin = $bin;
 
         /** @var string $encoded */
-        $encoded = \json_encode($decoded);
+        $encoded = \json_encode(
+            $decoded,
+            Format\JsonEncodeOptions::default()->toInt(),
+        );
 
         return Json::fromString($encoded);
     }

--- a/src/Vendor/Composer/PackageHashNormalizer.php
+++ b/src/Vendor/Composer/PackageHashNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Vendor\Composer;
 
 use Ergebnis\Json\Json;
+use Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Normalizer;
 
 final class PackageHashNormalizer implements Normalizer
@@ -60,7 +61,10 @@ final class PackageHashNormalizer implements Normalizer
         }
 
         /** @var string $encoded */
-        $encoded = \json_encode($decoded);
+        $encoded = \json_encode(
+            $decoded,
+            Format\JsonEncodeOptions::default()->toInt(),
+        );
 
         return Json::fromString($encoded);
     }

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Vendor\Composer;
 
 use Ergebnis\Json\Json;
+use Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Normalizer;
 
 final class VersionConstraintNormalizer implements Normalizer
@@ -70,7 +71,10 @@ final class VersionConstraintNormalizer implements Normalizer
         }
 
         /** @var string $encoded */
-        $encoded = \json_encode($decoded);
+        $encoded = \json_encode(
+            $decoded,
+            Format\JsonEncodeOptions::default()->toInt(),
+        );
 
         return Json::fromString($encoded);
     }

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -30,6 +30,15 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
 {
     use Test\Util\Helper;
 
+    public function testDefaultReturnsJsonEncodeOptions(): void
+    {
+        $jsonEncodeOptions = Format\JsonEncodeOptions::default();
+
+        $expected = 0;
+
+        self::assertSame($expected, $jsonEncodeOptions->toInt());
+    }
+
     /**
      * @dataProvider provideInvalidValue
      */

--- a/test/Unit/SchemaNormalizerTest.php
+++ b/test/Unit/SchemaNormalizerTest.php
@@ -36,6 +36,7 @@ use JsonSchema\SchemaStorage;
  * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriCouldNotBeResolved
  * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesDocumentWithInvalidMediaType
  * @uses \Ergebnis\Json\Normalizer\Exception\SchemaUriReferencesInvalidJsonDocument
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  */
 final class SchemaNormalizerTest extends AbstractNormalizerTestCase
 {

--- a/test/Unit/Vendor/Composer/BinNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/BinNormalizerTest.php
@@ -20,6 +20,8 @@ use Ergebnis\Json\Normalizer\Vendor;
  * @internal
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\BinNormalizer
+ *
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  */
 final class BinNormalizerTest extends AbstractComposerTestCase
 {
@@ -81,8 +83,9 @@ JSON
 JSON
         );
 
-        $expected = \json_encode(\json_decode(
-            <<<'JSON'
+        $expected = \json_encode(
+            \json_decode(
+                <<<'JSON'
 {
   "bin": [
     "another-script.php",
@@ -94,7 +97,9 @@ JSON
   }
 }
 JSON
-        ));
+            ),
+            0,
+        );
 
         $normalizer = new Vendor\Composer\BinNormalizer();
 

--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -23,6 +23,7 @@ use Ergebnis\Json\Normalizer\Vendor;
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\ComposerJsonNormalizer
  *
  * @uses \Ergebnis\Json\Normalizer\ChainNormalizer
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  * @uses \Ergebnis\Json\Normalizer\SchemaNormalizer
  * @uses \Ergebnis\Json\Normalizer\Vendor\Composer\BinNormalizer
  * @uses \Ergebnis\Json\Normalizer\Vendor\Composer\PackageHashNormalizer

--- a/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/PackageHashNormalizerTest.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace Ergebnis\Json\Normalizer\Test\Unit\Vendor\Composer;
 
 use Ergebnis\Json\Json;
+use Ergebnis\Json\Normalizer\Format;
 use Ergebnis\Json\Normalizer\Vendor;
 
 /**
  * @internal
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\PackageHashNormalizer
+ *
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  */
 final class PackageHashNormalizerTest extends AbstractComposerTestCase
 {
@@ -56,7 +59,10 @@ JSON
 JSON
         );
 
-        $expected = \json_encode(\json_decode($json->encoded()));
+        $expected = \json_encode(
+            \json_decode($json->encoded()),
+            0,
+        );
 
         $normalizer = new Vendor\Composer\PackageHashNormalizer();
 
@@ -91,8 +97,9 @@ JSON
 JSON
         );
 
-        $expected = \json_encode(\json_decode(
-            <<<JSON
+        $expected = \json_encode(
+            \json_decode(
+                <<<JSON
 {
   "{$property}": {
     "php": "Because why not, it's great.",
@@ -110,7 +117,9 @@ JSON
   }
 }
 JSON
-        ));
+            ),
+            Format\JsonEncodeOptions::default()->toInt(),
+        );
 
         $normalizer = new Vendor\Composer\PackageHashNormalizer();
 

--- a/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/VersionConstraintNormalizerTest.php
@@ -20,6 +20,8 @@ use Ergebnis\Json\Normalizer\Vendor;
  * @internal
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer
+ *
+ * @uses \Ergebnis\Json\Normalizer\Format\JsonEncodeOptions
  */
 final class VersionConstraintNormalizerTest extends AbstractComposerTestCase
 {
@@ -70,7 +72,10 @@ JSON
 JSON
         );
 
-        $expected = \json_encode(\json_decode($json->encoded()));
+        $expected = \json_encode(
+            \json_decode($json->encoded()),
+            0,
+        );
 
         $normalizer = new Vendor\Composer\VersionConstraintNormalizer();
 


### PR DESCRIPTION

This pull request

- [x] introduces a named constructor for default `json_encode()` options

Related to https://github.com/ergebnis/composer-normalize/issues/965.