### PR TITLE
Enhancement: Encode JSON with `JSON_PRESERVE_ZERO_FRACTION` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Adjusted `Vendor\Composer\BinNormalizer`, `Vendor\Composer\PackageHashNormalizer`, `Vendor\Composer\VersionConstraintNormalizer`, and `SchemaNormalizer` to encode JSON with `JSON_PRETTY_PRINT` flag ([#795]), by [@localheinz]
 - Adjusted `Vendor\Composer\BinNormalizer`, `Vendor\Composer\PackageHashNormalizer`, `Vendor\Composer\VersionConstraintNormalizer`, and `SchemaNormalizer` to encode JSON with `JSON_UNESCAPED_SLASHES` flag ([#801]), by [@localheinz]
 - Adjusted `Vendor\Composer\BinNormalizer`, `Vendor\Composer\PackageHashNormalizer`, `Vendor\Composer\VersionConstraintNormalizer`, and `SchemaNormalizer` to encode JSON with `JSON_UNESCAPED_UNICODE` flag ([#802]), by [@localheinz]
+- Adjusted `Vendor\Composer\BinNormalizer`, `Vendor\Composer\PackageHashNormalizer`, `Vendor\Composer\VersionConstraintNormalizer`, and `SchemaNormalizer` to encode JSON with `JSON_PRESERVE_ZERO_FRACTION` flag ([#803]), by [@localheinz]
 
 ### Fixed
 
@@ -552,6 +553,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#795]: https://github.com/ergebnis/json-normalizer/pull/795
 [#801]: https://github.com/ergebnis/json-normalizer/pull/801
 [#802]: https://github.com/ergebnis/json-normalizer/pull/802
+[#803]: https://github.com/ergebnis/json-normalizer/pull/803
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Format/JsonEncodeOptions.php
+++ b/src/Format/JsonEncodeOptions.php
@@ -27,7 +27,7 @@ final class JsonEncodeOptions
 
     public static function default(): self
     {
-        return new self(\JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+        return new self(\JSON_PRESERVE_ZERO_FRACTION | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -34,7 +34,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
     {
         $jsonEncodeOptions = Format\JsonEncodeOptions::default();
 
-        $expected = \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE;
+        $expected = \JSON_PRESERVE_ZERO_FRACTION | \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE;
 
         self::assertSame($expected, $jsonEncodeOptions->toInt());
     }


### PR DESCRIPTION
This pull request

- [x] encodes JSON with the `JSON_PRESERVE_ZERO_FRACTION` flag

Related to https://github.com/ergebnis/composer-normalize/issues/965.