### PR TITLE
Move composer/semver requirement to correct group

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -14,7 +14,6 @@
     "static",
     "string",
     "true",
-    "void",
-    "Composer\\Semver\\VersionParser"
+    "void"
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   "require": {
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
     "ext-json": "*",
+    "composer/semver": "^3.0.0",
     "ergebnis/json": "^1.0.1",
     "ergebnis/json-pointer": "^3.2.0",
     "ergebnis/json-printer": "^3.3.0",
@@ -28,7 +29,6 @@
     "justinrainbow/json-schema": "^5.2.12"
   },
   "require-dev": {
-    "composer/semver": "^3.0.0",
     "ergebnis/data-provider": "^1.3.0",
     "ergebnis/license": "^2.1.0",
     "ergebnis/php-cs-fixer-config": "^5.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ba8da9f3e36ff3ace1bee4b1b66eb4a",
+    "content-hash": "490d5fafbbe0b4edb1bf4b187a13da75",
     "packages": [
         {
             "name": "ergebnis/json",


### PR DESCRIPTION
This pull request moves the `composer/semver` requirement from `require-dev` to `require` to fix the complaint from `composer-require-checker`. This package was introduced as an active requirement (rather than only a development requirement) in https://github.com/ergebnis/json-normalizer/commit/06611333f6332d4c203c05a26600c4f324dd822a#diff-3fabe30a0ad02a8be3823a1acac081c8f5439dce42b48229d18df2f115ee4f26R16