### PR TITLE
Sort version numbers in ascending order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to reject JSON when it is not an object ([#804]), by [@localheinz]
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to compose `WithFinalNewLineNormalizer` ([#806]), by [@localheinz]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to skip normalization of version constraints when they can not be parsed by `Composer\Semver\VersionParser` ([#813]), by [@fredden] and [@localheinz]
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to sort versions in ascending order ([#816]), by [@fredden]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to normalize version constraints separators in `and` constraints from space (` `) or comma (`,`) to space (` `) ([#819]), by [@fredden]
 
 ### Fixed
@@ -560,6 +561,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#804]: https://github.com/ergebnis/json-normalizer/pull/804
 [#805]: https://github.com/ergebnis/json-normalizer/pull/805
 [#813]: https://github.com/ergebnis/json-normalizer/pull/813
+[#816]: https://github.com/ergebnis/json-normalizer/pull/816
 [#819]: https://github.com/ergebnis/json-normalizer/pull/819
 
 [@BackEndTea]: https://github.com/BackEndTea

--- a/README.md
+++ b/README.md
@@ -500,6 +500,17 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    }
   ```
 
+- version numbers are sorted in ascending order
+
+  ```diff
+   {
+     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+     "require": {
+  -    "foo/bar": "^2.0 || ^1.4"
+  +    "foo/bar": "^1.4 || ^2.0"
+   }
+  ```
+
 :bulb: Find out more about version constraints at [Composer: Version and Constraints](https://getcomposer.org/doc/articles/versions.md).
 
 ## Changelog

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "justinrainbow/json-schema": "^5.2.12"
   },
   "require-dev": {
-    "composer/semver": "^3.0.0",
+    "composer/semver": "^3.2.1",
     "ergebnis/data-provider": "^1.3.0",
     "ergebnis/license": "^2.1.0",
     "ergebnis/php-cs-fixer-config": "^5.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78761b51e6a192c95a2ce1c72a0311f0",
+    "content-hash": "601a4c7768337affcba811f2b6a350fc",
     "packages": [
         {
             "name": "ergebnis/json",

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-comma-exact-version-unsorted/01-without-spaces-trimmed": "2.3.4 1.2 0",
-        "combination-and-comma-exact-version-unsorted/02-without-spaces-untrimmed": "2.3.4 1.2 0",
-        "combination-and-comma-exact-version-unsorted/03-with-space-single-trimmed": "2.3.4 1.2 0",
-        "combination-and-comma-exact-version-unsorted/04-with-space-single-untrimmed": "2.3.4 1.2 0",
-        "combination-and-comma-exact-version-unsorted/05-with-space-double-trimmed": "2.3.4 1.2 0",
-        "combination-and-comma-exact-version-unsorted/06-with-space-double-untrimmed": "2.3.4 1.2 0"
+        "combination-and-comma-exact-version-unsorted/01-without-spaces-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unsorted/02-without-spaces-untrimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unsorted/03-with-space-single-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unsorted/04-with-space-single-untrimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unsorted/05-with-space-double-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unsorted/06-with-space-double-untrimmed": "0 1.2 2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Space/ExactVersion/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Space/ExactVersion/Unsorted/normalized.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-space-exact-version-unsorted/01-with-space-single-trimmed": "2.3.4 1.2 0",
-        "combination-and-space-exact-version-unsorted/02-with-space-single-untrimmed": "2.3.4 1.2 0",
-        "combination-and-space-exact-version-unsorted/03-with-space-double-trimmed": "2.3.4 1.2 0",
-        "combination-and-space-exact-version-unsorted/04-with-space-double-untrimmed": "2.3.4 1.2 0"
+        "combination-and-space-exact-version-unsorted/01-with-space-single-trimmed": "0 1.2 2.3.4",
+        "combination-and-space-exact-version-unsorted/02-with-space-single-untrimmed": "0 1.2 2.3.4",
+        "combination-and-space-exact-version-unsorted/03-with-space-double-trimmed": "0 1.2 2.3.4",
+        "combination-and-space-exact-version-unsorted/04-with-space-double-untrimmed": "0 1.2 2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/ExactVersion/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/ExactVersion/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-exact-version-unsorted/01-without-spaces-trimmed": "2.3.4 || 1.2 || 0",
-        "combination-or-exact-version-unsorted/02-without-spaces-untrimmed": "2.3.4 || 1.2 || 0",
-        "combination-or-exact-version-unsorted/03-with-single-space-trimmed": "2.3.4 || 1.2 || 0",
-        "combination-or-exact-version-unsorted/04-with-single-space-untrimmed": "2.3.4 || 1.2 || 0",
-        "combination-or-exact-version-unsorted/05-with-double-space-trimmed": "2.3.4 || 1.2 || 0",
-        "combination-or-exact-version-unsorted/06-with-double-space-untrimmed": "2.3.4 || 1.2 || 0"
+        "combination-or-exact-version-unsorted/01-without-spaces-trimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-unsorted/02-without-spaces-untrimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-unsorted/03-with-single-space-trimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-unsorted/04-with-single-space-untrimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-unsorted/05-with-double-space-trimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-unsorted/06-with-double-space-untrimmed": "0 || 1.2 || 2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-caret-unsorted/01-without-spaces-trimmed": "^2.3.4 || ^1.2 || ^0",
-        "combination-or-version-range-caret-unsorted/02-without-spaces-untrimmed": "^2.3.4 || ^1.2 || ^0",
-        "combination-or-version-range-caret-unsorted/03-with-single-space-trimmed": "^2.3.4 || ^1.2 || ^0",
-        "combination-or-version-range-caret-unsorted/04-with-single-space-untrimmed": "^2.3.4 || ^1.2 || ^0",
-        "combination-or-version-range-caret-unsorted/05-with-double-space-trimmed": "^2.3.4 || ^1.2 || ^0",
-        "combination-or-version-range-caret-unsorted/06-with-double-space-untrimmed": "^2.3.4 || ^1.2 || ^0"
+        "combination-or-version-range-caret-unsorted/01-without-spaces-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-unsorted/02-without-spaces-untrimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-unsorted/03-with-single-space-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-unsorted/04-with-single-space-untrimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-unsorted/05-with-double-space-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-unsorted/06-with-double-space-untrimmed": "^0 || ^1.2 || ^2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-tilde-unsorted/01-without-spaces-trimmed": "~2.3.4 || ~1.2 || ~0",
-        "combination-or-version-range-tilde-unsorted/02-without-spaces-untrimmed": "~2.3.4 || ~1.2 || ~0",
-        "combination-or-version-range-tilde-unsorted/03-with-single-space-trimmed": "~2.3.4 || ~1.2 || ~0",
-        "combination-or-version-range-tilde-unsorted/04-with-single-space-untrimmed": "~2.3.4 || ~1.2 || ~0",
-        "combination-or-version-range-tilde-unsorted/05-with-double-space-trimmed": "~2.3.4 || ~1.2 || ~0",
-        "combination-or-version-range-tilde-unsorted/06-with-double-space-untrimmed": "~2.3.4 || ~1.2 || ~0"
+        "combination-or-version-range-tilde-unsorted/01-without-spaces-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-unsorted/02-without-spaces-untrimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-unsorted/03-with-single-space-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-unsorted/04-with-single-space-untrimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-unsorted/05-with-double-space-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-unsorted/06-with-double-space-untrimmed": "~0 || ~1.2 || ~2.3.4"
     }
 }


### PR DESCRIPTION
This pull request is a small part of https://github.com/ergebnis/json-normalizer/pull/756. This change should not introduce any controversy.

- [x] version numbers are sorted in ascending order (`^2.0 || ^1.4` -> `^1.4 || ^2.0`)

Related to https://github.com/ergebnis/json-normalizer/pull/756