### PR TITLE
Always use a single space for `and` combinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to reject JSON when it is not an object ([#804]), by [@localheinz]
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to compose `WithFinalNewLineNormalizer` ([#806]), by [@localheinz]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to skip normalization of version constraints when they can not be parsed by `Composer\Semver\VersionParser` ([#813]), by [@fredden] and [@localheinz]
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to normalize version constraints separators in `and` constraints from space (` `) or comma (`,`) to space (` `) ([#819]), by [@fredden]
 
 ### Fixed
 
@@ -559,6 +560,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#804]: https://github.com/ergebnis/json-normalizer/pull/804
 [#805]: https://github.com/ergebnis/json-normalizer/pull/805
 [#813]: https://github.com/ergebnis/json-normalizer/pull/813
+[#819]: https://github.com/ergebnis/json-normalizer/pull/819
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/README.md
+++ b/README.md
@@ -453,7 +453,20 @@ When `composer.json` contains version constraints in the
 sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
 
 - all constraints are trimmed
-- *and- constraints are separated by a single space (` `) or a comma (`,`)
+
+- version constraints separated by a space (` `) or comma (`,`) - treated as a logical and - are separated by a space (` `) instead
+
+  ```diff
+   {
+     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+     "require": {
+  -    "foo/bar": "1.2.3,2.3.4",
+  -    "foo/baz": "2.3.4   3.4.5"
+  +    "foo/bar": "1.2.3 2.3.4",
+  +    "foo/baz": "2.3.4 3.4.5"
+   }
+  ```
+
 - *or- constraints are separated by double-pipe with a single space before and after (` || `)
 - *range- constraints are separated by a single space (` `)
 

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -30,7 +30,7 @@ final class VersionConstraintNormalizer implements Normalizer
     private const MAP = [
         'and' => [
             '{\s*,\s*}',
-            ',',
+            ' ',
         ],
         'or' => [
             '{\s*\|\|?\s*}',

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Duplicate/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Duplicate/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-comma-exact-version-duplicate/01-without-spaces-trimmed": "0,0,1.2,1.2,2.3.4,2.3.4",
-        "combination-and-comma-exact-version-duplicate/02-without-spaces-untrimmed": "0,0,1.2,1.2,2.3.4,2.3.4",
-        "combination-and-comma-exact-version-duplicate/03-with-space-single-trimmed": "0,0,1.2,1.2,2.3.4,2.3.4",
-        "combination-and-comma-exact-version-duplicate/04-with-space-single-untrimmed": "0,0,1.2,1.2,2.3.4,2.3.4",
-        "combination-and-comma-exact-version-duplicate/05-with-space-double-trimmed": "0,0,1.2,1.2,2.3.4,2.3.4",
-        "combination-and-comma-exact-version-duplicate/06-with-space-double-untrimmed": "0,0,1.2,1.2,2.3.4,2.3.4"
+        "combination-and-comma-exact-version-duplicate/01-without-spaces-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
+        "combination-and-comma-exact-version-duplicate/02-without-spaces-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
+        "combination-and-comma-exact-version-duplicate/03-with-space-single-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
+        "combination-and-comma-exact-version-duplicate/04-with-space-single-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
+        "combination-and-comma-exact-version-duplicate/05-with-space-double-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
+        "combination-and-comma-exact-version-duplicate/06-with-space-double-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unique/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unique/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-comma-exact-version-unique/01-without-spaces-trimmed": "0,1.2,2.3.4",
-        "combination-and-comma-exact-version-unique/02-without-spaces-untrimmed": "0,1.2,2.3.4",
-        "combination-and-comma-exact-version-unique/03-with-space-single-trimmed": "0,1.2,2.3.4",
-        "combination-and-comma-exact-version-unique/04-with-space-single-untrimmed": "0,1.2,2.3.4",
-        "combination-and-comma-exact-version-unique/05-with-space-double-trimmed": "0,1.2,2.3.4",
-        "combination-and-comma-exact-version-unique/06-with-space-double-untrimmed": "0,1.2,2.3.4"
+        "combination-and-comma-exact-version-unique/01-without-spaces-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unique/02-without-spaces-untrimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unique/03-with-space-single-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unique/04-with-space-single-untrimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unique/05-with-space-double-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-unique/06-with-space-double-untrimmed": "0 1.2 2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-comma-exact-version-unsorted/01-without-spaces-trimmed": "2.3.4,1.2,0",
-        "combination-and-comma-exact-version-unsorted/02-without-spaces-untrimmed": "2.3.4,1.2,0",
-        "combination-and-comma-exact-version-unsorted/03-with-space-single-trimmed": "2.3.4,1.2,0",
-        "combination-and-comma-exact-version-unsorted/04-with-space-single-untrimmed": "2.3.4,1.2,0",
-        "combination-and-comma-exact-version-unsorted/05-with-space-double-trimmed": "2.3.4,1.2,0",
-        "combination-and-comma-exact-version-unsorted/06-with-space-double-untrimmed": "2.3.4,1.2,0"
+        "combination-and-comma-exact-version-unsorted/01-without-spaces-trimmed": "2.3.4 1.2 0",
+        "combination-and-comma-exact-version-unsorted/02-without-spaces-untrimmed": "2.3.4 1.2 0",
+        "combination-and-comma-exact-version-unsorted/03-with-space-single-trimmed": "2.3.4 1.2 0",
+        "combination-and-comma-exact-version-unsorted/04-with-space-single-untrimmed": "2.3.4 1.2 0",
+        "combination-and-comma-exact-version-unsorted/05-with-space-double-trimmed": "2.3.4 1.2 0",
+        "combination-and-comma-exact-version-unsorted/06-with-space-double-untrimmed": "2.3.4 1.2 0"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/Or/ExactVersion/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/Or/ExactVersion/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-comma-or-exact-version/01-without-spaces-trimmed": "1,2.3 || 3.4.5",
-        "combination-and-comma-or-exact-version/02-without-spaces-untrimmed": "1,2.3 || 3.4.5",
-        "combination-and-comma-or-exact-version/03-with-space-single-trimmed": "1,2.3 || 3.4.5",
-        "combination-and-comma-or-exact-version/04-with-space-single-untrimmed": "1,2.3 || 3.4.5",
-        "combination-and-comma-or-exact-version/05-with-space-double-trimmed": "1,2.3 || 3.4.5",
-        "combination-and-comma-or-exact-version/06-with-space-double-untrimmed": "1,2.3 || 3.4.5"
+        "combination-and-comma-or-exact-version/01-without-spaces-trimmed": "1 2.3 || 3.4.5",
+        "combination-and-comma-or-exact-version/02-without-spaces-untrimmed": "1 2.3 || 3.4.5",
+        "combination-and-comma-or-exact-version/03-with-space-single-trimmed": "1 2.3 || 3.4.5",
+        "combination-and-comma-or-exact-version/04-with-space-single-untrimmed": "1 2.3 || 3.4.5",
+        "combination-and-comma-or-exact-version/05-with-space-double-trimmed": "1 2.3 || 3.4.5",
+        "combination-and-comma-or-exact-version/06-with-space-double-untrimmed": "1 2.3 || 3.4.5"
     }
 }


### PR DESCRIPTION
This pull request is a small part of https://github.com/ergebnis/json-normalizer/pull/756. This change should not introduce any controversy.

- [x] *and- constraints are always separated by a single space (` `), never a comma (`,`)

Related to https://github.com/ergebnis/json-normalizer/pull/756