### PR TITLE
Remove overlapping constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to skip normalization of version constraints when they can not be parsed by `Composer\Semver\VersionParser` ([#813]), by [@fredden] and [@localheinz]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to sort versions in ascending order ([#816]), by [@fredden]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to normalize version constraints separators in `and` constraints from space (` `) or comma (`,`) to space (` `) ([#819]), by [@fredden]
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to remove overlapping version constraints in `or` version constraints ([#850]), by [@fredden]
 
 ### Fixed
 
@@ -563,6 +564,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#813]: https://github.com/ergebnis/json-normalizer/pull/813
 [#816]: https://github.com/ergebnis/json-normalizer/pull/816
 [#819]: https://github.com/ergebnis/json-normalizer/pull/819
+[#850]: https://github.com/ergebnis/json-normalizer/pull/850
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/README.md
+++ b/README.md
@@ -500,6 +500,17 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    }
   ```
 
+- overlapping constraints are removed
+
+  ```diff
+   {
+     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+     "require": {
+  -    "foo/bar": "^1.0 || ^1.1 || ^2.0"
+  +    "foo/bar": "^1.0 || ^2.0"
+   }
+  ```
+
 - version numbers are sorted in ascending order
 
   ```diff

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -15,6 +15,7 @@
     "string",
     "true",
     "void",
+    "Composer\\Semver\\Semver",
     "Composer\\Semver\\VersionParser"
   ]
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Duplicate/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Duplicate/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-caret-duplicate/01-without-spaces-trimmed": "^0 || ^0 || ^1.2 || ^1.2 || ^2.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-duplicate/02-without-spaces-untrimmed": "^0 || ^0 || ^1.2 || ^1.2 || ^2.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-duplicate/03-with-single-space-trimmed": "^0 || ^0 || ^1.2 || ^1.2 || ^2.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-duplicate/04-with-single-space-untrimmed": "^0 || ^0 || ^1.2 || ^1.2 || ^2.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-duplicate/05-with-double-space-trimmed": "^0 || ^0 || ^1.2 || ^1.2 || ^2.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-duplicate/06-with-double-space-untrimmed": "^0 || ^0 || ^1.2 || ^1.2 || ^2.3.4 || ^2.3.4"
+        "combination-or-version-range-caret-duplicate/01-without-spaces-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-duplicate/02-without-spaces-untrimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-duplicate/03-with-single-space-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-duplicate/04-with-single-space-untrimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-duplicate/05-with-double-space-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-duplicate/06-with-double-space-untrimmed": "^0 || ^1.2 || ^2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Overlapping/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Overlapping/normalized.json
@@ -1,11 +1,13 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-caret-overlapping/01-without-spaces-trimmed": "^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5",
-        "combination-or-version-range-caret-overlapping/02-without-spaces-untrimmed": "^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5",
-        "combination-or-version-range-caret-overlapping/03-with-single-space-trimmed": "^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5",
-        "combination-or-version-range-caret-overlapping/04-with-single-space-untrimmed": "^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5",
-        "combination-or-version-range-caret-overlapping/05-with-double-space-trimmed": "^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5",
-        "combination-or-version-range-caret-overlapping/06-with-double-space-untrimmed": "^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5"
+        "combination-or-version-range-caret-overlapping/01-without-spaces-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-overlapping/02-without-spaces-untrimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-overlapping/03-with-single-space-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-overlapping/04-with-single-space-untrimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-overlapping/05-with-double-space-trimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-overlapping/06-with-double-space-untrimmed": "^0 || ^1.2 || ^2.3.4",
+        "combination-or-version-range-caret-overlapping/07-mix-major-minor-overlaps": "^0.1 || ^0.2 || ^0.3 || ^1.0 || ^2.8 || ^3.4",
+        "combination-or-version-range-caret-overlapping/08-out-of-order": "^1.0 || ^2.2 || ^3.4 || ^4.1.6"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Overlapping/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Overlapping/original.json
@@ -6,6 +6,8 @@
     "combination-or-version-range-caret-overlapping/03-with-single-space-trimmed": "^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5",
     "combination-or-version-range-caret-overlapping/04-with-single-space-untrimmed": " ^0 || ^1.2 || ^1.3 || ^2.3.4 || ^2.4.5 ",
     "combination-or-version-range-caret-overlapping/05-with-double-space-trimmed": "^0  ||  ^1.2  ||  ^1.3  ||  ^2.3.4  ||  ^2.4.5",
-    "combination-or-version-range-caret-overlapping/06-with-double-space-untrimmed": " ^0  ||  ^1.2  ||  ^1.3  ||  ^2.3.4  ||  ^2.4.5 "
+    "combination-or-version-range-caret-overlapping/06-with-double-space-untrimmed": " ^0  ||  ^1.2  ||  ^1.3  ||  ^2.3.4  ||  ^2.4.5 ",
+    "combination-or-version-range-caret-overlapping/07-mix-major-minor-overlaps": "^0.1 || ^0.2 || ^0.2.1 || ^0.3 || ^0.3.4 || ^1.0 || ^1.1 || ^1.2.3 || ^2.8 || ^3.4 || ^3.5.6",
+    "combination-or-version-range-caret-overlapping/08-out-of-order": "^3.7.2 || ^2.8 || ^1.14 || ^4.5 || ^3.4 || ^2.2 || ^4.1.6 || ^1.0"
   }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Duplicate/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Duplicate/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-tilde-duplicate/01-without-spaces-trimmed": "~0 || ~0 || ~1.2 || ~1.2 || ~2.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-duplicate/02-without-spaces-untrimmed": "~0 || ~0 || ~1.2 || ~1.2 || ~2.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-duplicate/03-with-single-space-trimmed": "~0 || ~0 || ~1.2 || ~1.2 || ~2.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-duplicate/04-with-single-space-untrimmed": "~0 || ~0 || ~1.2 || ~1.2 || ~2.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-duplicate/05-with-double-space-trimmed": "~0 || ~0 || ~1.2 || ~1.2 || ~2.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-duplicate/06-with-double-space-untrimmed": "~0 || ~0 || ~1.2 || ~1.2 || ~2.3.4 || ~2.3.4"
+        "combination-or-version-range-tilde-duplicate/01-without-spaces-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-duplicate/02-without-spaces-untrimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-duplicate/03-with-single-space-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-duplicate/04-with-single-space-untrimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-duplicate/05-with-double-space-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-duplicate/06-with-double-space-untrimmed": "~0 || ~1.2 || ~2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Overlapping/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Overlapping/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-tilde-overlapping/01-without-spaces-trimmed": "~0 || ~1.2 || ~1.3 || ~2.3.4 || ~2.3.5",
-        "combination-or-version-range-tilde-overlapping/02-without-spaces-untrimmed": "~0 || ~1.2 || ~1.3 || ~2.3.4 || ~2.3.5",
-        "combination-or-version-range-tilde-overlapping/03-with-single-space-trimmed": "~0 || ~1.2 || ~1.3 || ~2.3.4 || ~2.3.5",
-        "combination-or-version-range-tilde-overlapping/04-with-single-space-untrimmed": "~0 || ~1.2 || ~1.3 || ~2.3.4 || ~2.3.5",
-        "combination-or-version-range-tilde-overlapping/05-with-double-space-trimmed": "~0 || ~1.2 || ~1.3 || ~2.3.4 || ~2.3.5",
-        "combination-or-version-range-tilde-overlapping/06-with-double-space-untrimmed": "~0 || ~1.2 || ~1.3 || ~2.3.4 || ~2.3.5"
+        "combination-or-version-range-tilde-overlapping/01-without-spaces-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-overlapping/02-without-spaces-untrimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-overlapping/03-with-single-space-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-overlapping/04-with-single-space-untrimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-overlapping/05-with-double-space-trimmed": "~0 || ~1.2 || ~2.3.4",
+        "combination-or-version-range-tilde-overlapping/06-with-double-space-untrimmed": "~0 || ~1.2 || ~2.3.4"
     }
 }


### PR DESCRIPTION
This pull request is a small part of https://github.com/ergebnis/json-normalizer/pull/756. This change seems less controversial than some of the other changes being suggested in #756.

- [x] overlapping constraints are removed (`^1.0 || ^1.1 || ^2.0` -> `^1.0 || ^2.0`)

Related to #756