### PR TITLE
Enhancement: Adjust `VersionConstraintNormalizer` to remove duplicate version constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For a full diff see [`3.0.0...main`][3.0.0...main].
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to sort versions in ascending order ([#816]), by [@fredden]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to normalize version constraints separators in `and` constraints from space (` `) or comma (`,`) to space (` `) ([#819]), by [@fredden]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to remove overlapping version constraints in `or` version constraints ([#850]), by [@fredden]
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to remove duplicate version constraints ([#856]), by [@localheinz]
 
 ### Fixed
 
@@ -565,6 +566,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#816]: https://github.com/ergebnis/json-normalizer/pull/816
 [#819]: https://github.com/ergebnis/json-normalizer/pull/819
 [#850]: https://github.com/ergebnis/json-normalizer/pull/850
+[#856]: https://github.com/ergebnis/json-normalizer/pull/856
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/README.md
+++ b/README.md
@@ -500,6 +500,17 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    }
   ```
 
+- duplicate constraints are removed
+
+  ```diff
+   {
+     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+     "require": {
+  -    "foo/bar": "^1.0 || ^1.0 || ^2.0"
+  +    "foo/bar": "^1.0 || ^2.0"
+   }
+  ```
+
 - overlapping constraints are removed
 
   ```diff

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -81,6 +81,7 @@ final class VersionConstraintNormalizer implements Normalizer
         }
 
         $normalized = self::normalizeVersionConstraintSeparators($normalized);
+        $normalized = self::removeDuplicateVersionConstraints($normalized);
         $normalized = self::sortOrConstraints($normalized);
 
         return self::removeOverlappingConstraints($normalized);
@@ -104,6 +105,17 @@ final class VersionConstraintNormalizer implements Normalizer
 
             return self::joinAndConstraints(...$andConstraints);
         }, $orConstraints));
+    }
+
+    private static function removeDuplicateVersionConstraints(string $versionConstraint): string
+    {
+        $orConstraints = self::splitIntoOrConstraints($versionConstraint);
+
+        return self::joinOrConstraints(...\array_unique(\array_map(static function (string $orConstraint): string {
+            $andConstraints = self::splitIntoAndConstraints($orConstraint);
+
+            return self::joinAndConstraints(...\array_unique($andConstraints));
+        }, $orConstraints)));
     }
 
     private static function sortOrConstraints(string $versionConstraint): string

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Duplicate/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Duplicate/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-comma-exact-version-duplicate/01-without-spaces-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-comma-exact-version-duplicate/02-without-spaces-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-comma-exact-version-duplicate/03-with-space-single-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-comma-exact-version-duplicate/04-with-space-single-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-comma-exact-version-duplicate/05-with-space-double-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-comma-exact-version-duplicate/06-with-space-double-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4"
+        "combination-and-comma-exact-version-duplicate/01-without-spaces-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-duplicate/02-without-spaces-untrimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-duplicate/03-with-space-single-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-duplicate/04-with-space-single-untrimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-duplicate/05-with-space-double-trimmed": "0 1.2 2.3.4",
+        "combination-and-comma-exact-version-duplicate/06-with-space-double-untrimmed": "0 1.2 2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Space/ExactVersion/Duplicate/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Space/ExactVersion/Duplicate/normalized.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-space-exact-version-duplicate/01-with-space-single-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-space-exact-version-duplicate/02-with-space-single-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-space-exact-version-duplicate/03-with-space-double-trimmed": "0 0 1.2 1.2 2.3.4 2.3.4",
-        "combination-and-space-exact-version-duplicate/04-with-space-double-untrimmed": "0 0 1.2 1.2 2.3.4 2.3.4"
+        "combination-and-space-exact-version-duplicate/01-with-space-single-trimmed": "0 1.2 2.3.4",
+        "combination-and-space-exact-version-duplicate/02-with-space-single-untrimmed": "0 1.2 2.3.4",
+        "combination-and-space-exact-version-duplicate/03-with-space-double-trimmed": "0 1.2 2.3.4",
+        "combination-and-space-exact-version-duplicate/04-with-space-double-untrimmed": "0 1.2 2.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/ExactVersion/Duplicate/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/ExactVersion/Duplicate/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-exact-version-duplicate/01-without-spaces-trimmed": "0 || 0 || 1.2 || 1.2 || 2.3.4 || 2.3.4",
-        "combination-or-exact-version-duplicate/02-without-spaces-untrimmed": "0 || 0 || 1.2 || 1.2 || 2.3.4 || 2.3.4",
-        "combination-or-exact-version-duplicate/03-with-single-space-trimmed": "0 || 0 || 1.2 || 1.2 || 2.3.4 || 2.3.4",
-        "combination-or-exact-version-duplicate/04-with-single-space-untrimmed": "0 || 0 || 1.2 || 1.2 || 2.3.4 || 2.3.4",
-        "combination-or-exact-version-duplicate/05-with-double-space-trimmed": "0 || 0 || 1.2 || 1.2 || 2.3.4 || 2.3.4",
-        "combination-or-exact-version-duplicate/06-with-double-space-untrimmed": "0 || 0 || 1.2 || 1.2 || 2.3.4 || 2.3.4"
+        "combination-or-exact-version-duplicate/01-without-spaces-trimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-duplicate/02-without-spaces-untrimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-duplicate/03-with-single-space-trimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-duplicate/04-with-single-space-untrimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-duplicate/05-with-double-space-trimmed": "0 || 1.2 || 2.3.4",
+        "combination-or-exact-version-duplicate/06-with-double-space-untrimmed": "0 || 1.2 || 2.3.4"
     }
 }


### PR DESCRIPTION
This pull request

- [x] adjusts the `VersionConstraintNormalizer` to remove duplicate version constraints