### PR TITLE
Fix: Do not sort `repositories` by key

### DIFF
--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -76,6 +76,13 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                         return 1 === \preg_match('{^\/extra\/patches\/([^/])+$}', $jsonPointer->toJsonString());
                     }),
                     /**
+                     * Repositories need to be iterated in a specific order, but can be an array or an object.
+                     *
+                     * @see https://getcomposer.org/doc/04-schema.md#repositories
+                     * @see https://github.com/composer/composer/blob/2.5.4/res/composer-schema.json#L187-L207
+                     */
+                    Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/repositories')),
+                    /**
                      * Commands need to executed in a specific order.
                      *
                      * @see https://github.com/symfony/flex/blob/v2.2.3/src/Flex.php#L517-L519

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsObject/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsObject/normalized.json
@@ -15,13 +15,13 @@
     ],
     "homepage": "https://getcomposer.org/doc/04-schema.md#repositories",
     "repositories": {
-        "bar": {
-            "type": "composer",
-            "url": "http://packages.bar.com"
-        },
         "foo": {
             "type": "composer",
             "url": "http://packages.foo.com"
+        },
+        "bar": {
+            "type": "composer",
+            "url": "http://packages.bar.com"
         }
     }
 }


### PR DESCRIPTION
This pull request

- [x] asserts that repositories are not sorted by key
- [x] stops sorting repositories by key

Fixes https://github.com/ergebnis/composer-normalize/issues/1059.
