### PR TITLE
Fix: Revert inlining of `BinNormalizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.0.0...main`][4.0.0...main].
 ## Fixed
 
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `repositories` ([#858]), by [@localheinz]
+- Reverted inlining `Vendor\Composer\BinNormalizer` ([#860]), by [@localheinz]
 
 ## [`4.0.0`][4.0.0]
 
@@ -576,6 +577,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#850]: https://github.com/ergebnis/json-normalizer/pull/850
 [#856]: https://github.com/ergebnis/json-normalizer/pull/856
 [#858]: https://github.com/ergebnis/json-normalizer/pull/858
+[#860]: https://github.com/ergebnis/json-normalizer/pull/860
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/README.md
+++ b/README.md
@@ -415,13 +415,14 @@ The `Vendor\Composer\ComposerJsonNormalizer` can be used to normalize a `compose
 
 It composes the following normalizers:
 
+- [`Ergebnis\Composer\Json\Normalizer\Vendor\Composer\BinNormalizer`](#vendorcomposerbinnormalizer)
 - [`Ergebnis\Composer\Json\Normalizer\Vendor\Composer\PackageHashNormalizer`](#vendorcomposerpackagehashnormalizer)
 - [`Ergebnis\Composer\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer`](#vendorcomposerversionconstraintnormalizer)
 - [`Ergebnis\Composer\Json\Normalizer\Vendor\WithFinalNewLineNormalizer`](#withfinalnewlinenormalizer)
 
-#### `bin`
+#### `Vendor\Composer\BinNormalizer`
 
-When `composer.json` contains an array of scripts in the `bin` section, the `Vendor\Composer\ComposerJsonNormalizer` will sort the elements of the `bin` section by value in ascending order.
+When `composer.json` contains an array of scripts in the `bin` section, the `Vendor\Composer\BinNormalizer` will sort the elements of the `bin` section by value in ascending order.
 
 :bulb: Find out more about the `bin` section at [Composer: The composer.json schema](https://getcomposer.org/doc/04-schema.md#bin).
 

--- a/src/Vendor/Composer/BinNormalizer.php
+++ b/src/Vendor/Composer/BinNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/json-normalizer
+ */
+
+namespace Ergebnis\Json\Normalizer\Vendor\Composer;
+
+use Ergebnis\Json\Json;
+use Ergebnis\Json\Normalizer\Format;
+use Ergebnis\Json\Normalizer\Normalizer;
+
+final class BinNormalizer implements Normalizer
+{
+    public function normalize(Json $json): Json
+    {
+        $decoded = $json->decoded();
+
+        if (!\is_object($decoded)) {
+            return $json;
+        }
+
+        if (!\property_exists($decoded, 'bin')) {
+            return $json;
+        }
+
+        if (!\is_array($decoded->bin)) {
+            return $json;
+        }
+
+        $bin = $decoded->bin;
+
+        \sort($bin);
+
+        $decoded->bin = $bin;
+
+        /** @var string $encoded */
+        $encoded = \json_encode(
+            $decoded,
+            Format\JsonEncodeOptions::default()->toInt(),
+        );
+
+        return Json::fromString($encoded);
+    }
+}

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -90,7 +90,7 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
                 ),
             ),
-            self::binNormalizer(),
+            new BinNormalizer(),
             new PackageHashNormalizer(),
             new VersionConstraintNormalizer(new Semver\VersionParser()),
             new Normalizer\WithFinalNewLineNormalizer(),
@@ -100,38 +100,5 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
     public function normalize(Json $json): Json
     {
         return $this->normalizer->normalize($json);
-    }
-
-    private static function binNormalizer(): Normalizer\Normalizer
-    {
-        return new class() implements Normalizer\Normalizer {
-            public function normalize(Json $json): Json
-            {
-                /** @var object $decoded */
-                $decoded = $json->decoded();
-
-                if (!\property_exists($decoded, 'bin')) {
-                    return $json;
-                }
-
-                if (!\is_array($decoded->bin)) {
-                    return $json;
-                }
-
-                $bin = $decoded->bin;
-
-                \sort($bin);
-
-                $decoded->bin = $bin;
-
-                /** @var string $encoded */
-                $encoded = \json_encode(
-                    $decoded,
-                    Normalizer\Format\JsonEncodeOptions::default()->toInt(),
-                );
-
-                return Json::fromString($encoded);
-            }
-        };
     }
 }

--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework;
 /**
  * @internal
  *
+ * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\BinNormalizer
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\ComposerJsonNormalizer
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\PackageHashNormalizer
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer


### PR DESCRIPTION
This pull request

- [x] reverts the inlining of the `BinNormalizer`
