### PR TITLE
Fix: Sort `config` by key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`4.0.0...main`][4.0.0...main].
 
 - Adjusted `Vendor\Composer\ComposerJsonNormalizer` to stop sorting `repositories` ([#858]), by [@localheinz]
 - Reverted inlining `Vendor\Composer\BinNormalizer` ([#860]), by [@localheinz]
+- Partially reverted removal of `Vendor\Composer\ConfigHashNormalizer` to ensure `config` is sorted by ket ([#861]), by [@localheinz]
 
 ## [`4.0.0`][4.0.0]
 
@@ -579,6 +580,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#856]: https://github.com/ergebnis/json-normalizer/pull/856
 [#858]: https://github.com/ergebnis/json-normalizer/pull/858
 [#860]: https://github.com/ergebnis/json-normalizer/pull/860
+[#861]: https://github.com/ergebnis/json-normalizer/pull/861
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ The `Vendor\Composer\ComposerJsonNormalizer` can be used to normalize a `compose
 It composes the following normalizers:
 
 - [`Ergebnis\Composer\Json\Normalizer\Vendor\Composer\BinNormalizer`](#vendorcomposerbinnormalizer)
+- [`Ergebnis\Composer\Json\Normalizer\Vendor\Composer\ConfigHashNormalizer`](#vendorcomposerconfighashnormalizer)
 - [`Ergebnis\Composer\Json\Normalizer\Vendor\Composer\PackageHashNormalizer`](#vendorcomposerpackagehashnormalizer)
 - [`Ergebnis\Composer\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer`](#vendorcomposerversionconstraintnormalizer)
 - [`Ergebnis\Composer\Json\Normalizer\Vendor\WithFinalNewLineNormalizer`](#withfinalnewlinenormalizer)
@@ -425,6 +426,12 @@ It composes the following normalizers:
 When `composer.json` contains an array of scripts in the `bin` section, the `Vendor\Composer\BinNormalizer` will sort the elements of the `bin` section by value in ascending order.
 
 :bulb: Find out more about the `bin` section at [Composer: The composer.json schema](https://getcomposer.org/doc/04-schema.md#bin).
+
+#### `Vendor\Composer\ConfigHashNormalizer`
+
+When `composer.json` contains configuration in the `config` section, the `Vendor\Composer\ConfigHashNormalizer` will sort the content of these sections by key in ascending order.
+
+:bulb: Find out more about the `config` section at [Composer: The composer.json schema](https://getcomposer.org/doc/06-config.md).
 
 #### `Vendor\Composer\PackageHashNormalizer`
 

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -91,6 +91,7 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                 ),
             ),
             new BinNormalizer(),
+            new ConfigHashNormalizer(),
             new PackageHashNormalizer(),
             new VersionConstraintNormalizer(new Semver\VersionParser()),
             new Normalizer\WithFinalNewLineNormalizer(),

--- a/src/Vendor/Composer/ConfigHashNormalizer.php
+++ b/src/Vendor/Composer/ConfigHashNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018-2023 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/json-normalizer
+ */
+
+namespace Ergebnis\Json\Normalizer\Vendor\Composer;
+
+use Ergebnis\Json\Json;
+use Ergebnis\Json\Normalizer\Format;
+use Ergebnis\Json\Normalizer\Normalizer;
+
+final class ConfigHashNormalizer implements Normalizer
+{
+    public function normalize(Json $json): Json
+    {
+        $decoded = $json->decoded();
+
+        if (!\is_object($decoded)) {
+            return $json;
+        }
+
+        if (!\property_exists($decoded, 'config')) {
+            return $json;
+        }
+
+        if (!\is_object($decoded->config)) {
+            return $json;
+        }
+
+        /** @var array<string, mixed> $config */
+        $config = (array) $decoded->config;
+
+        if ([] === $config) {
+            return $json;
+        }
+
+        \ksort($config);
+
+        $decoded->config = $config;
+
+        /** @var string $encoded */
+        $encoded = \json_encode(
+            $decoded,
+            Format\JsonEncodeOptions::default()->toInt(),
+        );
+
+        return Json::fromString($encoded);
+    }
+}

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/No/normalized.json
@@ -15,10 +15,10 @@
     ],
     "homepage": "https://getcomposer.org/doc/06-config.md",
     "config": {
+        "allow-plugins": {},
         "platform": {
             "php": "8.0.25"
         },
-        "allow-plugins": {},
         "preferred-install": "dist",
         "sort-packages": true
     }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
@@ -15,10 +15,10 @@
     ],
     "homepage": "https://getcomposer.org/doc/06-config.md",
     "config": {
+        "allow-plugins": {},
         "platform": {
             "php": "8.0.25"
         },
-        "allow-plugins": {},
         "preferred-install": "dist",
         "sort-packages": true
     }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/Yes/original.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/Yes/original.json
@@ -15,10 +15,10 @@
   ],
   "homepage": "https://getcomposer.org/doc/06-config.md",
   "config": {
+    "allow-plugins": {},
     "platform": {
       "php": "8.0.25"
     },
-    "allow-plugins": {},
     "preferred-install": "dist",
     "sort-packages": true
   }

--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework;
  *
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\BinNormalizer
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\ComposerJsonNormalizer
+ * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\ConfigHashNormalizer
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\PackageHashNormalizer
  * @covers \Ergebnis\Json\Normalizer\Vendor\Composer\VersionConstraintNormalizer
  *


### PR DESCRIPTION
This pull request

- [x] asserts that the `config` has is sorted by key
- [x] sorts the `config` hash by key

Fixes https://github.com/ergebnis/composer-normalize/issues/1058.