### PR TITLE
Fix: Sort versions naturally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`4.0.1...main`][4.0.1...main].
 
+### Fixed
+
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to sort versions naturally ([#863]), by [@localheinz]
+
 ## [`4.0.1`][4.0.1]
 
 For a full diff see [`4.0.0...4.0.1`][4.0.0...4.0.1].
@@ -587,6 +591,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#858]: https://github.com/ergebnis/json-normalizer/pull/858
 [#860]: https://github.com/ergebnis/json-normalizer/pull/860
 [#861]: https://github.com/ergebnis/json-normalizer/pull/861
+[#863]: https://github.com/ergebnis/json-normalizer/pull/863
 
 [@BackEndTea]: https://github.com/BackEndTea
 [@dependabot]: https://github.com/dependabot

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -174,7 +174,7 @@ final class VersionConstraintNormalizer implements Normalizer
         };
 
         $sort = static function (string $a, string $b) use ($normalize): int {
-            return \strcmp(
+            return \strnatcmp(
                 $normalize($a),
                 $normalize($b),
             );

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Comma/ExactVersion/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-comma-exact-version-unsorted/01-without-spaces-trimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-comma-exact-version-unsorted/02-without-spaces-untrimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-comma-exact-version-unsorted/03-with-space-single-trimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-comma-exact-version-unsorted/04-with-space-single-untrimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-comma-exact-version-unsorted/05-with-space-double-trimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-comma-exact-version-unsorted/06-with-space-double-untrimmed": "0 1.2 12.3.4 2.3.4"
+        "combination-and-comma-exact-version-unsorted/01-without-spaces-trimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-comma-exact-version-unsorted/02-without-spaces-untrimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-comma-exact-version-unsorted/03-with-space-single-trimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-comma-exact-version-unsorted/04-with-space-single-untrimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-comma-exact-version-unsorted/05-with-space-double-trimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-comma-exact-version-unsorted/06-with-space-double-untrimmed": "0 1.2 2.3.4 12.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Space/ExactVersion/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/And/Space/ExactVersion/Unsorted/normalized.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-and-space-exact-version-unsorted/01-with-space-single-trimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-space-exact-version-unsorted/02-with-space-single-untrimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-space-exact-version-unsorted/03-with-space-double-trimmed": "0 1.2 12.3.4 2.3.4",
-        "combination-and-space-exact-version-unsorted/04-with-space-double-untrimmed": "0 1.2 12.3.4 2.3.4"
+        "combination-and-space-exact-version-unsorted/01-with-space-single-trimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-space-exact-version-unsorted/02-with-space-single-untrimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-space-exact-version-unsorted/03-with-space-double-trimmed": "0 1.2 2.3.4 12.3.4",
+        "combination-and-space-exact-version-unsorted/04-with-space-double-untrimmed": "0 1.2 2.3.4 12.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/ExactVersion/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/ExactVersion/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-exact-version-unsorted/01-without-spaces-trimmed": "0 || 1.2 || 12.3.4 || 2.3.4",
-        "combination-or-exact-version-unsorted/02-without-spaces-untrimmed": "0 || 1.2 || 12.3.4 || 2.3.4",
-        "combination-or-exact-version-unsorted/03-with-single-space-trimmed": "0 || 1.2 || 12.3.4 || 2.3.4",
-        "combination-or-exact-version-unsorted/04-with-single-space-untrimmed": "0 || 1.2 || 12.3.4 || 2.3.4",
-        "combination-or-exact-version-unsorted/05-with-double-space-trimmed": "0 || 1.2 || 12.3.4 || 2.3.4",
-        "combination-or-exact-version-unsorted/06-with-double-space-untrimmed": "0 || 1.2 || 12.3.4 || 2.3.4"
+        "combination-or-exact-version-unsorted/01-without-spaces-trimmed": "0 || 1.2 || 2.3.4 || 12.3.4",
+        "combination-or-exact-version-unsorted/02-without-spaces-untrimmed": "0 || 1.2 || 2.3.4 || 12.3.4",
+        "combination-or-exact-version-unsorted/03-with-single-space-trimmed": "0 || 1.2 || 2.3.4 || 12.3.4",
+        "combination-or-exact-version-unsorted/04-with-single-space-untrimmed": "0 || 1.2 || 2.3.4 || 12.3.4",
+        "combination-or-exact-version-unsorted/05-with-double-space-trimmed": "0 || 1.2 || 2.3.4 || 12.3.4",
+        "combination-or-exact-version-unsorted/06-with-double-space-untrimmed": "0 || 1.2 || 2.3.4 || 12.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Caret/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-caret-unsorted/01-without-spaces-trimmed": "^0 || ^1.2 || ^12.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-unsorted/02-without-spaces-untrimmed": "^0 || ^1.2 || ^12.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-unsorted/03-with-single-space-trimmed": "^0 || ^1.2 || ^12.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-unsorted/04-with-single-space-untrimmed": "^0 || ^1.2 || ^12.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-unsorted/05-with-double-space-trimmed": "^0 || ^1.2 || ^12.3.4 || ^2.3.4",
-        "combination-or-version-range-caret-unsorted/06-with-double-space-untrimmed": "^0 || ^1.2 || ^12.3.4 || ^2.3.4"
+        "combination-or-version-range-caret-unsorted/01-without-spaces-trimmed": "^0 || ^1.2 || ^2.3.4 || ^12.3.4",
+        "combination-or-version-range-caret-unsorted/02-without-spaces-untrimmed": "^0 || ^1.2 || ^2.3.4 || ^12.3.4",
+        "combination-or-version-range-caret-unsorted/03-with-single-space-trimmed": "^0 || ^1.2 || ^2.3.4 || ^12.3.4",
+        "combination-or-version-range-caret-unsorted/04-with-single-space-untrimmed": "^0 || ^1.2 || ^2.3.4 || ^12.3.4",
+        "combination-or-version-range-caret-unsorted/05-with-double-space-trimmed": "^0 || ^1.2 || ^2.3.4 || ^12.3.4",
+        "combination-or-version-range-caret-unsorted/06-with-double-space-untrimmed": "^0 || ^1.2 || ^2.3.4 || ^12.3.4"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Unsorted/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Tilde/Unsorted/normalized.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-tilde-unsorted/01-without-spaces-trimmed": "~0 || ~1.2 || ~12.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-unsorted/02-without-spaces-untrimmed": "~0 || ~1.2 || ~12.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-unsorted/03-with-single-space-trimmed": "~0 || ~1.2 || ~12.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-unsorted/04-with-single-space-untrimmed": "~0 || ~1.2 || ~12.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-unsorted/05-with-double-space-trimmed": "~0 || ~1.2 || ~12.3.4 || ~2.3.4",
-        "combination-or-version-range-tilde-unsorted/06-with-double-space-untrimmed": "~0 || ~1.2 || ~12.3.4 || ~2.3.4"
+        "combination-or-version-range-tilde-unsorted/01-without-spaces-trimmed": "~0 || ~1.2 || ~2.3.4 || ~12.3.4",
+        "combination-or-version-range-tilde-unsorted/02-without-spaces-untrimmed": "~0 || ~1.2 || ~2.3.4 || ~12.3.4",
+        "combination-or-version-range-tilde-unsorted/03-with-single-space-trimmed": "~0 || ~1.2 || ~2.3.4 || ~12.3.4",
+        "combination-or-version-range-tilde-unsorted/04-with-single-space-untrimmed": "~0 || ~1.2 || ~2.3.4 || ~12.3.4",
+        "combination-or-version-range-tilde-unsorted/05-with-double-space-trimmed": "~0 || ~1.2 || ~2.3.4 || ~12.3.4",
+        "combination-or-version-range-tilde-unsorted/06-with-double-space-untrimmed": "~0 || ~1.2 || ~2.3.4 || ~12.3.4"
     }
 }


### PR DESCRIPTION
This pull request

- [x] asserts that versions are sorted naturally
- [x] sorts versions naturally

Related to https://github.com/ergebnis/composer-normalize/issues/1061.