### PR TITLE
Improve overlapping version removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`4.2.0...main`][4.2.0...main].
 ### Changed
 
 - Sort `allow-plugins` and `preferred-install` as sensibly as is feasible ([#980]), by [@fredden]
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to remove overlapping individual versions too ([#982]), by [@fredden]
 
 ## [`4.2.0`][4.2.0]
 
@@ -635,6 +636,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#889]: https://github.com/ergebnis/json-normalizer/pull/889
 [#917]: https://github.com/ergebnis/json-normalizer/pull/917
 [#980]: https://github.com/ergebnis/json-normalizer/pull/980
+[#982]: https://github.com/ergebnis/json-normalizer/pull/982
 
 [@alexis-saransig-lullabot]: https://github.com/alexis-saransig-lullabot
 [@BackEndTea]: https://github.com/BackEndTea

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    {
      "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
      "require": {
-  -    "foo/bar": "^1.0 || ^1.1 || ^2.0"
+  -    "foo/bar": "^1.0 || ^1.1 || ^2.0 || ~2.1.0 || 2.4.5"
   +    "foo/bar": "^1.0 || ^2.0"
    }
   ```

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -173,7 +173,7 @@ final class VersionConstraintNormalizer implements Normalizer
     {
         $orConstraints = self::splitIntoOrConstraints($versionConstraint);
 
-        $regex = '{^[~^]\d+(?:\.\d+)*$}';
+        $regex = '{^[~^]?\d+(?:\.\d+)*$}';
 
         $count = \count($orConstraints);
 

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/normalized.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "combination-or-version-range-mixed/01": "^1.2",
+        "combination-or-version-range-mixed/02": "^1.2",
+        "combination-or-version-range-mixed/03": "^1.2",
+        "combination-or-version-range-mixed/04": "1.2.1 || ~1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/normalized.json
@@ -1,9 +1,33 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
     "value-contains-packages-and-version-constraints": {
-        "combination-or-version-range-mixed/01": "^1.2",
-        "combination-or-version-range-mixed/02": "^1.2",
-        "combination-or-version-range-mixed/03": "^1.2",
-        "combination-or-version-range-mixed/04": "1.2.1 || ~1.2.3"
+        "combination-or-version-range-mixed/01-fixed-and-caret": "^1",
+        "combination-or-version-range-mixed/02-fixed-and-caret": "^1.2",
+        "combination-or-version-range-mixed/03-fixed-and-caret-zero": "^1.2.0",
+        "combination-or-version-range-mixed/04-fixed-and-caret-non-zero": "^1.2.1",
+        "combination-or-version-range-mixed/05-fixed-and-caret-same": "^1.2.3",
+        "combination-or-version-range-mixed/06-fixed-and-caret-greater": "1.2.3 || ^1.2.5",
+        "combination-or-version-range-mixed/07-fixed-and-tilde": "^1",
+        "combination-or-version-range-mixed/08-fixed-and-tilde": "^1.2",
+        "combination-or-version-range-mixed/09-fixed-and-tilde-zero": "~1.2.0",
+        "combination-or-version-range-mixed/10-fixed-and-tilde-non-zero": "~1.2.2",
+        "combination-or-version-range-mixed/11-fixed-and-tilde-same": "~1.2.3",
+        "combination-or-version-range-mixed/12-fixed-and-tilde-greater": "1.2.3 || ~1.2.5",
+        "combination-or-version-range-mixed/13-fixed-and-wildcard": "^1.0",
+        "combination-or-version-range-mixed/14-fixed-and-wildcard": "~1.2.0",
+        "combination-or-version-range-mixed/15-tilde-and-caret": "^1.2",
+        "combination-or-version-range-mixed/16-wildcard-and-caret": "^1.2",
+        "combination-or-version-range-mixed/17-tilde-and-wildcard": "~1.2.0",
+        "combination-or-version-range-mixed/18-tilde-and-wildcard-and-caret": "^1.2",
+        "combination-or-version-range-mixed/19-fixed-and-tilde-and-caret": "^1.2",
+        "combination-or-version-range-mixed/20-fixed-and-wildcard-and-caret": "^1.2",
+        "combination-or-version-range-mixed/21-fixed-and-tilde-and-wildcard": "~1.2.0",
+        "combination-or-version-range-mixed/22-fixed-and-tilde-and-wildcard-and-caret": "^1.2",
+        "combination-or-version-range-mixed/23-fixed-and-tilde-and-caret": "^1.2.3",
+        "combination-or-version-range-mixed/24-tilde-and-caret-and-fixed": "^1.2.3",
+        "combination-or-version-range-mixed/25-caret-and-fixed-and-tilde": "^1.2.3",
+        "combination-or-version-range-mixed/26-caret-and-tilde-and-fixed": "^1.2.3",
+        "combination-or-version-range-mixed/27-tilde-and-fixed-and-caret": "^1.2.3",
+        "combination-or-version-range-mixed/28-fixed-and-caret-and-tilde": "^1.2.3"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/original.json
@@ -1,0 +1,9 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "combination-or-version-range-mixed/01": "1.2.3 || ^1.2",
+    "combination-or-version-range-mixed/02": "~1.2.3 || ^1.2",
+    "combination-or-version-range-mixed/03": "1.2.3 || ~1.2.1 || ^1.2",
+    "combination-or-version-range-mixed/04": "~1.2.3 || 1.2.1 || 1.2.4"
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Combination/Or/VersionRange/Mixed/original.json
@@ -1,9 +1,38 @@
 {
   "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
   "value-contains-packages-and-version-constraints": {
-    "combination-or-version-range-mixed/01": "1.2.3 || ^1.2",
-    "combination-or-version-range-mixed/02": "~1.2.3 || ^1.2",
-    "combination-or-version-range-mixed/03": "1.2.3 || ~1.2.1 || ^1.2",
-    "combination-or-version-range-mixed/04": "~1.2.3 || 1.2.1 || 1.2.4"
+    "combination-or-version-range-mixed/01-fixed-and-caret": "1.2.3 || ^1",
+    "combination-or-version-range-mixed/02-fixed-and-caret": "1.2.3 || ^1.2",
+    "combination-or-version-range-mixed/03-fixed-and-caret-zero": "1.2.3 || ^1.2.0",
+    "combination-or-version-range-mixed/04-fixed-and-caret-non-zero": "1.2.3 || ^1.2.1",
+    "combination-or-version-range-mixed/05-fixed-and-caret-same": "1.2.3 || ^1.2.3",
+    "combination-or-version-range-mixed/06-fixed-and-caret-greater": "1.2.3 || ^1.2.5",
+
+    "combination-or-version-range-mixed/07-fixed-and-tilde": "1.2.3 || ~1",
+    "combination-or-version-range-mixed/08-fixed-and-tilde": "1.2.3 || ~1.2",
+    "combination-or-version-range-mixed/09-fixed-and-tilde-zero": "1.2.3 || ~1.2.0",
+    "combination-or-version-range-mixed/10-fixed-and-tilde-non-zero": "1.2.3 || ~1.2.2",
+    "combination-or-version-range-mixed/11-fixed-and-tilde-same": "1.2.3 || ~1.2.3",
+    "combination-or-version-range-mixed/12-fixed-and-tilde-greater": "1.2.3 || ~1.2.5",
+
+    "combination-or-version-range-mixed/13-fixed-and-wildcard": "1.2.3 || 1.*",
+    "combination-or-version-range-mixed/14-fixed-and-wildcard": "1.2.3 || 1.2.*",
+
+    "combination-or-version-range-mixed/15-tilde-and-caret": "~1.2.3 || ^1.2",
+    "combination-or-version-range-mixed/16-wildcard-and-caret": "1.2.* || ^1.2",
+    "combination-or-version-range-mixed/17-tilde-and-wildcard": "~1.2.3 || 1.2.*",
+    "combination-or-version-range-mixed/18-tilde-and-wildcard-and-caret": "~1.2.3 || 1.2.* || ^1.2",
+
+    "combination-or-version-range-mixed/19-fixed-and-tilde-and-caret": "1.2.6 || ~1.2.3 || ^1.2",
+    "combination-or-version-range-mixed/20-fixed-and-wildcard-and-caret": "1.2.6 || 1.2.* || ^1.2",
+    "combination-or-version-range-mixed/21-fixed-and-tilde-and-wildcard": "1.2.6 || ~1.2.3 || 1.2.*",
+    "combination-or-version-range-mixed/22-fixed-and-tilde-and-wildcard-and-caret": "1.2.6 || ~1.2.3 || 1.2.* || ^1.2",
+
+    "combination-or-version-range-mixed/23-fixed-and-tilde-and-caret": "1.2.3 || ~1.2.3 || ^1.2.3",
+    "combination-or-version-range-mixed/24-tilde-and-caret-and-fixed": "~1.2.3 || ^1.2.3 || 1.2.3",
+    "combination-or-version-range-mixed/25-caret-and-fixed-and-tilde": "^1.2.3 || 1.2.3 || ~1.2.3",
+    "combination-or-version-range-mixed/26-caret-and-tilde-and-fixed": "^1.2.3 || ~1.2.3 || 1.2.3",
+    "combination-or-version-range-mixed/27-tilde-and-fixed-and-caret": "~1.2.3 || 1.2.3 || ^1.2.3",
+    "combination-or-version-range-mixed/28-fixed-and-caret-and-tilde": "1.2.3 || ^1.2.3 || ~1.2.3"
   }
 }


### PR DESCRIPTION
This pull request
- Ensures that specific version numbers already covered by a range are removed (3ecb33be7999a66b0f7517c70919bf04e4c08a32)
- Prefers caret version range operators over tilde version range operators when removing an overlap (3c5c1a4e7d51e87b28e7b52d48f66becd48a6047)
- Ensures that the order of operands does not impact the end result

Follows #850

----

Before these changes, `^1.2 || 1.3.4` would not be changed. After these changes this is replaced with `^1.2`.

Before these changes, `^1.2.0 || ~1.2.0` would be replaced with `~1.2.0`, which is incorrect. After these changes, both `^1.2.0 || ~1.2.0` and `~1.2.0 || ^1.2.0` are replaced with `^1.2.0`