### PR TITLE
Improve test coverage

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -36,17 +36,11 @@
     <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <UnusedForeachValue>
-      <code>$value</code>
-    </UnusedForeachValue>
   </file>
   <file src="src/Vendor/Composer/VersionConstraintNormalizer.php">
     <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <UnusedForeachValue>
-      <code>$value</code>
-    </UnusedForeachValue>
   </file>
   <file src="test/Fixture/FormatNormalizer/NormalizeNormalizesJson/Scenario.php">
     <PossiblyUnusedMethod>

--- a/src/Format/JsonEncodeOptions.php
+++ b/src/Format/JsonEncodeOptions.php
@@ -47,7 +47,7 @@ final class JsonEncodeOptions
         $jsonEncodeOptions = 0;
 
         if (!\str_contains($json->encoded(), '\/')) {
-            $jsonEncodeOptions |= \JSON_UNESCAPED_SLASHES;
+            $jsonEncodeOptions = \JSON_UNESCAPED_SLASHES;
         }
 
         if (1 !== \preg_match('/(\\\\+)u([0-9a-f]{4})/i', $json->encoded())) {

--- a/src/Format/NewLine.php
+++ b/src/Format/NewLine.php
@@ -30,7 +30,7 @@ final class NewLine
      */
     public static function fromString(string $value): self
     {
-        if (1 !== \preg_match('/^(?>\r\n|\n|\r)$/', $value)) {
+        if ("\n" !== $value && "\r" !== $value && "\r\n" !== $value) {
             throw Exception\InvalidNewLineString::fromString($value);
         }
 

--- a/src/Vendor/Composer/PackageHashNormalizer.php
+++ b/src/Vendor/Composer/PackageHashNormalizer.php
@@ -51,7 +51,7 @@ final class PackageHashNormalizer implements Normalizer
 
         foreach ($objectPropertiesThatShouldBeNormalized as $name => $value) {
             /** @var array<string, string> $packages */
-            $packages = (array) $decoded->{$name};
+            $packages = (array) $value;
 
             if ([] === $packages) {
                 continue;

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -50,7 +50,7 @@ final class VersionConstraintNormalizer implements Normalizer
         }
 
         foreach ($objectPropertiesThatShouldBeNormalized as $name => $value) {
-            $packages = (array) $decoded->{$name};
+            $packages = (array) $value;
 
             if ([] === $packages) {
                 continue;

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/RequireAndRequireDev/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/RequireAndRequireDev/normalized.json
@@ -1,0 +1,10 @@
+{
+    "description": "This test exists to cover certain mutants from infection/infection",
+    "require": {},
+    "require-dev": {
+        "ergebnis/overlapping-version-constraints-1": "^1.0 || 3.4.5",
+        "ergebnis/overlapping-version-constraints-2": "^1.0 || ^2.0",
+        "ergebnis/separator-mixing": "^1.0 || ^1.2 >=1.2.4 <1.2.7",
+        "ergebnis/whitespace-around-version": "*"
+    }
+}

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/RequireAndRequireDev/original.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/RequireAndRequireDev/original.json
@@ -1,0 +1,10 @@
+{
+  "description": "This test exists to cover certain mutants from infection/infection",
+  "require": {},
+  "require-dev": {
+    "ergebnis/whitespace-around-version": " * ",
+    "ergebnis/overlapping-version-constraints-1": "3.4.5 || ^1.0 || ^1.1 || ^1.2",
+    "ergebnis/overlapping-version-constraints-2": "^1.0 || ^2.0 || ^1.1 || ^2.1",
+    "ergebnis/separator-mixing": "^1.0 | ^1.1 || ^1.2,<1.2.7 >=1.2.4 || ^1.4"
+  }
+}

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
@@ -1,5 +1,6 @@
 {
     "homepage": "https://getcomposer.org/doc/04-schema.md#suggest",
+    "require": {},
     "suggest": {
         "php": "Nothing works without it",
         "hhvm": "Okay",

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/Yes/IsSortedByKey/Yes/original.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/Yes/IsSortedByKey/Yes/original.json
@@ -1,5 +1,6 @@
 {
   "homepage": "https://getcomposer.org/doc/04-schema.md#suggest",
+  "require": {},
   "suggest": {
     "php": "Nothing works without it",
     "hhvm": "Okay",

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/IsSortedByPackage/No/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/IsSortedByPackage/No/normalized.json
@@ -5,6 +5,7 @@
         "ext-foo": "*",
         "lib-baz": "*",
         "composer-plugin-api": "*",
+        "0-test/sort-order": "*",
         "acquia/drupal-environment-detector": "*",
         "ergebnis/php-cs-fixer-config": "*",
         "ergebnis/test-util": "*"

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/IsSortedByPackage/No/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/IsSortedByPackage/No/original.json
@@ -7,6 +7,7 @@
     "acquia/drupal-environment-detector": "*",
     "ext-foo": "*",
     "composer-plugin-api": "*",
+    "0-test/sort-order": "*",
     "php": "*"
   }
 }

--- a/test/Unit/Format/IndentTest.php
+++ b/test/Unit/Format/IndentTest.php
@@ -43,6 +43,7 @@ final class IndentTest extends Framework\TestCase
         $style = self::faker()->randomElement(\array_keys(Format\Indent::CHARACTERS));
 
         $this->expectException(Exception\InvalidIndentSize::class);
+        $this->expectExceptionMessage(\sprintf('Size needs to be greater than %d, but %d is not.', 0, $size));
 
         Format\Indent::fromSizeAndStyle(
             $size,
@@ -76,6 +77,7 @@ final class IndentTest extends Framework\TestCase
         $style = $faker->sentence();
 
         $this->expectException(Exception\InvalidIndentStyle::class);
+        $this->expectExceptionMessage(\sprintf('Style needs to be one of "space", "tab", but "%s" is not.', $style));
 
         Format\Indent::fromSizeAndStyle(
             $size,

--- a/test/Unit/Format/JsonEncodeOptionsTest.php
+++ b/test/Unit/Format/JsonEncodeOptionsTest.php
@@ -112,7 +112,7 @@ final class JsonEncodeOptionsTest extends Framework\TestCase
             [
                 \JSON_UNESCAPED_SLASHES,
                 '{
-  "name": "Andreas M\u00f6ller",
+  "name": "Andreas M\u00F6ller",
   "url": "https://github.com/ergebnis/json-normalizer"
 }',
             ],

--- a/test/Unit/Format/NewLineTest.php
+++ b/test/Unit/Format/NewLineTest.php
@@ -26,6 +26,7 @@ final class NewLineTest extends Framework\TestCase
     public function testFromStringRejectsInvalidNewLineString(string $string): void
     {
         $this->expectException(Exception\InvalidNewLineString::class);
+        $this->expectExceptionMessage(\sprintf('"%s" is not a valid new-line character sequence.', $string));
 
         Format\NewLine::fromString($string);
     }

--- a/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
+++ b/test/Unit/Vendor/Composer/ComposerJsonNormalizerTest.php
@@ -23,6 +23,7 @@ use Ergebnis\Json\Normalizer\Vendor;
 use Ergebnis\Json\Normalizer\WithFinalNewLineNormalizer;
 use PHPUnit\Framework;
 
+#[Framework\Attributes\CoversClass(SchemaNormalizer::class)]
 #[Framework\Attributes\CoversClass(Vendor\Composer\BinNormalizer::class)]
 #[Framework\Attributes\CoversClass(Vendor\Composer\ComposerJsonNormalizer::class)]
 #[Framework\Attributes\CoversClass(Vendor\Composer\ConfigHashNormalizer::class)]


### PR DESCRIPTION
This pull request contains some of the code from https://github.com/ergebnis/json-normalizer/pull/981, as suggested in https://github.com/ergebnis/json-normalizer/pull/981#issuecomment-1755608439. The changes here do not achieve a score of 100% from the mutation testing, but it is 7 percentage points higher than the minimum required, and does not increase the time it takes to run the mutation tests.

Each of the changes here were inspired by "escaped mutants" as reported by `infection/infection` when configured to not skip half of the tests.

Related to #981
