### PR TITLE
Remove leading `v` prefixes from version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`4.3.0...main`][4.3.0...main].
 
+### Changed
+
+- Started removing `v` prefixes from version constraints ([#1027]), by [@fredden]
+
 ## [`4.3.0`][4.3.0]
 
 For a full diff see [`4.2.0...4.3.0`][4.2.0...4.3.0].
@@ -651,6 +655,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#989]: https://github.com/ergebnis/json-normalizer/pull/989
 [#991]: https://github.com/ergebnis/json-normalizer/pull/991
 [#992]: https://github.com/ergebnis/json-normalizer/pull/992
+[#1027]: https://github.com/ergebnis/json-normalizer/pull/1027
 
 [@alexis-saransig-lullabot]: https://github.com/alexis-saransig-lullabot
 [@BackEndTea]: https://github.com/BackEndTea

--- a/README.md
+++ b/README.md
@@ -592,6 +592,19 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    }
   ```
 
+
+- leading `v` prefixes in version constraints are removed
+
+  ```diff
+   {
+     "require": {
+  -    "foo/bar": "^v1.2",
+  -    "foo/baz": "v1.3.7"
+  +    "foo/bar": "^1.2",
+  +    "foo/baz": "1.3.7"
+   }
+  ```
+
 ## Changelog
 
 The maintainers of this project record notable changes to this project in a [changelog](CHANGELOG.md).

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -82,6 +82,7 @@ final class VersionConstraintNormalizer implements Normalizer
     private function normalizeVersionConstraint(string $versionConstraint): string
     {
         $versionConstraint = self::normalizeVersionConstraintSeparators($versionConstraint);
+        $versionConstraint = self::removeLeadingVersionPrefix($versionConstraint);
         $versionConstraint = self::replaceWildcardWithTilde($versionConstraint);
         $versionConstraint = self::replaceTildeWithCaret($versionConstraint);
         $versionConstraint = self::removeDuplicateVersionConstraints($versionConstraint);
@@ -167,6 +168,27 @@ final class VersionConstraintNormalizer implements Normalizer
 
             return self::joinAndConstraints(...\array_unique($andConstraints));
         }, $orConstraints)));
+    }
+
+    private static function removeLeadingVersionPrefix(string $versionConstraint): string
+    {
+        $split = \explode(
+            ' ',
+            $versionConstraint,
+        );
+
+        foreach ($split as &$part) {
+            $part = \preg_replace(
+                '{^(|[!<>]=|[~<>^])v(\d+.*)$}',
+                '$1$2',
+                $part,
+            );
+        }
+
+        return \implode(
+            ' ',
+            $split,
+        );
     }
 
     private static function removeOverlappingVersionConstraints(string $versionConstraint): string

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#caret-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-caret-stable/01-major-trimmed": "^1",
+        "leading-v-caret-stable/02-major-untrimmed": "^1",
+        "leading-v-caret-stable/03-major-minor-trimmed": "^1.2",
+        "leading-v-caret-stable/04-major-minor-untrimmed": "^1.2",
+        "leading-v-caret-stable/05-major-minor-patch-trimmed": "^1.2.3",
+        "leading-v-caret-stable/06-major-minor-patch-untrimmed": "^1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#caret-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-caret-stable/01-major-trimmed": "^v1",
+    "leading-v-caret-stable/02-major-untrimmed": " ^v1 ",
+    "leading-v-caret-stable/03-major-minor-trimmed": "^v1.2",
+    "leading-v-caret-stable/04-major-minor-untrimmed": " ^v1.2 ",
+    "leading-v-caret-stable/05-major-minor-patch-trimmed": "^v1.2.3",
+    "leading-v-caret-stable/06-major-minor-patch-untrimmed": " ^v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#caret-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-caret-unstable/01-major-trimmed": "^0",
+        "leading-v-caret-unstable/02-major-untrimmed": "^0",
+        "leading-v-caret-unstable/03-major-minor-trimmed": "^0.1",
+        "leading-v-caret-unstable/04-major-minor-untrimmed": "^0.1",
+        "leading-v-caret-unstable/05-major-minor-patch-trimmed": "^0.1.2",
+        "leading-v-caret-unstable/06-major-minor-patch-untrimmed": "^0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Caret/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#caret-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-caret-unstable/01-major-trimmed": "^v0",
+    "leading-v-caret-unstable/02-major-untrimmed": " ^v0 ",
+    "leading-v-caret-unstable/03-major-minor-trimmed": "^v0.1",
+    "leading-v-caret-unstable/04-major-minor-untrimmed": " ^v0.1 ",
+    "leading-v-caret-unstable/05-major-minor-patch-trimmed": "^v0.1.2",
+    "leading-v-caret-unstable/06-major-minor-patch-untrimmed": " ^v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#exact-version-constraint",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-exact-version-stable/01-major-trimmed": "1",
+        "leading-v-exact-version-stable/02-major-untrimmed": "1",
+        "leading-v-exact-version-stable/03-major-minor-trimmed": "1.2",
+        "leading-v-exact-version-stable/04-major-minor-untrimmed": "1.2",
+        "leading-v-exact-version-stable/05-major-minor-patch-trimmed": "1.2.3",
+        "leading-v-exact-version-stable/06-major-minor-patch-untrimmed": "1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#exact-version-constraint",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-exact-version-stable/01-major-trimmed": "v1",
+    "leading-v-exact-version-stable/02-major-untrimmed": " v1 ",
+    "leading-v-exact-version-stable/03-major-minor-trimmed": "v1.2",
+    "leading-v-exact-version-stable/04-major-minor-untrimmed": " v1.2 ",
+    "leading-v-exact-version-stable/05-major-minor-patch-trimmed": "v1.2.3",
+    "leading-v-exact-version-stable/06-major-minor-patch-untrimmed": " v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#exact-version-constraint",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-exact-version-unstable/01-major-trimmed": "0",
+        "leading-v-exact-version-unstable/02-major-untrimmed": "0",
+        "leading-v-exact-version-unstable/03-major-minor-trimmed": "0.1",
+        "leading-v-exact-version-unstable/04-major-minor-untrimmed": "0.1",
+        "leading-v-exact-version-unstable/05-major-minor-patch-trimmed": "0.1.2",
+        "leading-v-exact-version-unstable/06-major-minor-patch-untrimmed": "0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/ExactVersion/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#exact-version-constraint",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-exact-version-unstable/01-major-trimmed": "v0",
+    "leading-v-exact-version-unstable/02-major-untrimmed": " v0 ",
+    "leading-v-exact-version-unstable/03-major-minor-trimmed": "v0.1",
+    "leading-v-exact-version-unstable/04-major-minor-untrimmed": " v0.1 ",
+    "leading-v-exact-version-unstable/05-major-minor-patch-trimmed": "v0.1.2",
+    "leading-v-exact-version-unstable/06-major-minor-patch-untrimmed": " v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-greater-than-stable/01-major-trimmed": ">1",
+        "leading-v-greater-than-stable/02-major-untrimmed": ">1",
+        "leading-v-greater-than-stable/03-major-minor-trimmed": ">1.2",
+        "leading-v-greater-than-stable/04-major-minor-untrimmed": ">1.2",
+        "leading-v-greater-than-stable/05-major-minor-patch-trimmed": ">1.2.3",
+        "leading-v-greater-than-stable/06-major-minor-patch-untrimmed": ">1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-greater-than-stable/01-major-trimmed": ">v1",
+    "leading-v-greater-than-stable/02-major-untrimmed": " >v1 ",
+    "leading-v-greater-than-stable/03-major-minor-trimmed": " >v1.2 ",
+    "leading-v-greater-than-stable/04-major-minor-untrimmed": " >v1.2 ",
+    "leading-v-greater-than-stable/05-major-minor-patch-trimmed": ">v1.2.3",
+    "leading-v-greater-than-stable/06-major-minor-patch-untrimmed": " >v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-greater-than-unstable/01-major-trimmed": ">0",
+        "leading-v-greater-than-unstable/02-major-untrimmed": ">0",
+        "leading-v-greater-than-unstable/03-major-minor-trimmed": ">0.1",
+        "leading-v-greater-than-unstable/04-major-minor-untrimmed": ">0.1",
+        "leading-v-greater-than-unstable/05-major-minor-patch-trimmed": ">0.1.2",
+        "leading-v-greater-than-unstable/06-major-minor-patch-untrimmed": ">0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThan/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-greater-than-unstable/01-major-trimmed": ">v0",
+    "leading-v-greater-than-unstable/02-major-untrimmed": " >v0 ",
+    "leading-v-greater-than-unstable/03-major-minor-trimmed": " >v0.1 ",
+    "leading-v-greater-than-unstable/04-major-minor-untrimmed": " >v0.1 ",
+    "leading-v-greater-than-unstable/05-major-minor-patch-trimmed": ">v0.1.2",
+    "leading-v-greater-than-unstable/06-major-minor-patch-untrimmed": " >v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-greater-than-or-equal-stable/01-major-trimmed": ">=1",
+        "leading-v-greater-than-or-equal-stable/02-major-untrimmed": ">=1",
+        "leading-v-greater-than-or-equal-stable/03-major-minor-trimmed": ">=1.2",
+        "leading-v-greater-than-or-equal-stable/04-major-minor-untrimmed": ">=1.2",
+        "leading-v-greater-than-or-equal-stable/05-major-minor-patch-trimmed": ">=1.2.3",
+        "leading-v-greater-than-or-equal-stable/06-major-minor-patch-untrimmed": ">=1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-greater-than-or-equal-stable/01-major-trimmed": ">=v1",
+    "leading-v-greater-than-or-equal-stable/02-major-untrimmed": " >=v1 ",
+    "leading-v-greater-than-or-equal-stable/03-major-minor-trimmed": " >=v1.2 ",
+    "leading-v-greater-than-or-equal-stable/04-major-minor-untrimmed": " >=v1.2 ",
+    "leading-v-greater-than-or-equal-stable/05-major-minor-patch-trimmed": ">=v1.2.3",
+    "leading-v-greater-than-or-equal-stable/06-major-minor-patch-untrimmed": " >=v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-greater-than-or-equal-unstable/01-major-trimmed": ">=0",
+        "leading-v-greater-than-or-equal-unstable/02-major-untrimmed": ">=0",
+        "leading-v-greater-than-or-equal-unstable/03-major-minor-trimmed": ">=0.1",
+        "leading-v-greater-than-or-equal-unstable/04-major-minor-untrimmed": ">=0.1",
+        "leading-v-greater-than-or-equal-unstable/05-major-minor-patch-trimmed": ">=0.1.2",
+        "leading-v-greater-than-or-equal-unstable/06-major-minor-patch-untrimmed": ">=0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/GreaterThanOrEqual/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-greater-than-or-equal-unstable/01-major-trimmed": ">=v0",
+    "leading-v-greater-than-or-equal-unstable/02-major-untrimmed": " >=v0 ",
+    "leading-v-greater-than-or-equal-unstable/03-major-minor-trimmed": " >=v0.1 ",
+    "leading-v-greater-than-or-equal-unstable/04-major-minor-untrimmed": " >=v0.1 ",
+    "leading-v-greater-than-or-equal-unstable/05-major-minor-patch-trimmed": ">=v0.1.2",
+    "leading-v-greater-than-or-equal-unstable/06-major-minor-patch-untrimmed": " >=v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Stable/normalized.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#hyphenated-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-hyphenated-stable/01-major-surrounded-by-space-single-trimmed": "1 - 2",
+        "leading-v-hyphenated-stable/02-major-surrounded-by-space-single-untrimmed": "1 - 2",
+        "leading-v-hyphenated-stable/03-major-surrounded-by-space-double-trimmed": "1 - 2",
+        "leading-v-hyphenated-stable/04-major-surrounded-by-space-double-untrimmed": "1 - 2",
+        "leading-v-hyphenated-stable/05-major-minor-surrounded-by-space-single-trimmed": "1.2 - 2.3",
+        "leading-v-hyphenated-stable/06-major-minor-surrounded-by-space-single-untrimmed": "1.2 - 2.3",
+        "leading-v-hyphenated-stable/07-major-minor-surrounded-by-space-double-trimmed": "1.2 - 2.3",
+        "leading-v-hyphenated-stable/08-major-minor-surrounded-by-space-double-untrimmed": "1.2 - 2.3",
+        "leading-v-hyphenated-stable/09-major-minor-patch-surrounded-by-space-single-trimmed": "1.2.3 - 2.3.4",
+        "leading-v-hyphenated-stable/10-major-minor-patch-surrounded-by-space-single-untrimmed": "1.2.3 - 2.3.4",
+        "leading-v-hyphenated-stable/11-major-minor-patch-surrounded-by-space-double-trimmed": "1.2.3 - 2.3.4",
+        "leading-v-hyphenated-stable/12-major-minor-patch-surrounded-by-space-double-untrimmed": "1.2.3 - 2.3.4"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Stable/original.json
@@ -1,0 +1,17 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#hyphenated-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-hyphenated-stable/01-major-surrounded-by-space-single-trimmed": "v1 - v2",
+    "leading-v-hyphenated-stable/02-major-surrounded-by-space-single-untrimmed": " v1 - v2 ",
+    "leading-v-hyphenated-stable/03-major-surrounded-by-space-double-trimmed": "v1  -  v2",
+    "leading-v-hyphenated-stable/04-major-surrounded-by-space-double-untrimmed": " v1  -  v2 ",
+    "leading-v-hyphenated-stable/05-major-minor-surrounded-by-space-single-trimmed": "v1.2 - v2.3",
+    "leading-v-hyphenated-stable/06-major-minor-surrounded-by-space-single-untrimmed": " v1.2 - v2.3 ",
+    "leading-v-hyphenated-stable/07-major-minor-surrounded-by-space-double-trimmed": "v1.2  -  v2.3",
+    "leading-v-hyphenated-stable/08-major-minor-surrounded-by-space-double-untrimmed": " v1.2  -  v2.3 ",
+    "leading-v-hyphenated-stable/09-major-minor-patch-surrounded-by-space-single-trimmed": "v1.2.3 - v2.3.4",
+    "leading-v-hyphenated-stable/10-major-minor-patch-surrounded-by-space-single-untrimmed": " v1.2.3 - v2.3.4 ",
+    "leading-v-hyphenated-stable/11-major-minor-patch-surrounded-by-space-double-trimmed": "v1.2.3  -  v2.3.4",
+    "leading-v-hyphenated-stable/12-major-minor-patch-surrounded-by-space-double-untrimmed": " v1.2.3  -  v2.3.4"
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Unstable/normalized.json
@@ -1,0 +1,13 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#hyphenated-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-hyphenated-unstable/01-major-minor-surrounded-by-space-single-trimmed": "0.1 - 0.2",
+        "leading-v-hyphenated-unstable/02-major-minor-surrounded-by-space-single-untrimmed": "0.1 - 0.2",
+        "leading-v-hyphenated-unstable/03-major-minor-surrounded-by-space-double-trimmed": "0.1 - 0.2",
+        "leading-v-hyphenated-unstable/04-major-minor-surrounded-by-space-double-untrimmed": "0.1 - 0.2",
+        "leading-v-hyphenated-unstable/05-major-minor-patch-surrounded-by-space-single-trimmed": "0.1.2 - 0.2.3",
+        "leading-v-hyphenated-unstable/06-major-minor-patch-surrounded-by-space-single-untrimmed": "0.1.2 - 0.2.3",
+        "leading-v-hyphenated-unstable/07-major-minor-patch-surrounded-by-space-double-trimmed": "0.1.2 - 0.2.3",
+        "leading-v-hyphenated-unstable/08-major-minor-patch-surrounded-by-space-double-untrimmed": "0.1.2 - 0.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Hyphenated/Unstable/original.json
@@ -1,0 +1,13 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#hyphenated-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-hyphenated-unstable/01-major-minor-surrounded-by-space-single-trimmed": "v0.1 - v0.2",
+    "leading-v-hyphenated-unstable/02-major-minor-surrounded-by-space-single-untrimmed": " v0.1 - v0.2 ",
+    "leading-v-hyphenated-unstable/03-major-minor-surrounded-by-space-double-trimmed": "v0.1  -  v0.2",
+    "leading-v-hyphenated-unstable/04-major-minor-surrounded-by-space-double-untrimmed": " v0.1  -  v0.2 ",
+    "leading-v-hyphenated-unstable/05-major-minor-patch-surrounded-by-space-single-trimmed": "v0.1.2 - v0.2.3",
+    "leading-v-hyphenated-unstable/06-major-minor-patch-surrounded-by-space-single-untrimmed": " v0.1.2 - v0.2.3 ",
+    "leading-v-hyphenated-unstable/07-major-minor-patch-surrounded-by-space-double-trimmed": "v0.1.2  -  v0.2.3",
+    "leading-v-hyphenated-unstable/08-major-minor-patch-surrounded-by-space-double-untrimmed": " v0.1.2  -  v0.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-less-than-stable/01-major-trimmed": "<1",
+        "leading-v-less-than-stable/02-major-untrimmed": "<1",
+        "leading-v-less-than-stable/03-major-minor-trimmed": "<1.2",
+        "leading-v-less-than-stable/04-major-minor-untrimmed": "<1.2",
+        "leading-v-less-than-stable/05-major-minor-patch-trimmed": "<1.2.3",
+        "leading-v-less-than-stable/06-major-minor-patch-untrimmed": "<1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-less-than-stable/01-major-trimmed": "<v1",
+    "leading-v-less-than-stable/02-major-untrimmed": " <v1 ",
+    "leading-v-less-than-stable/03-major-minor-trimmed": " <v1.2 ",
+    "leading-v-less-than-stable/04-major-minor-untrimmed": " <v1.2 ",
+    "leading-v-less-than-stable/05-major-minor-patch-trimmed": "<v1.2.3",
+    "leading-v-less-than-stable/06-major-minor-patch-untrimmed": " <v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-less-than-unstable/01-major-trimmed": "<0",
+        "leading-v-less-than-unstable/02-major-untrimmed": "<0",
+        "leading-v-less-than-unstable/03-major-minor-trimmed": "<0.1",
+        "leading-v-less-than-unstable/04-major-minor-untrimmed": "<0.1",
+        "leading-v-less-than-unstable/05-major-minor-patch-trimmed": "<0.1.2",
+        "leading-v-less-than-unstable/06-major-minor-patch-untrimmed": "<0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThan/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-less-than-unstable/01-major-trimmed": "<v0",
+    "leading-v-less-than-unstable/02-major-untrimmed": " <v0 ",
+    "leading-v-less-than-unstable/03-major-minor-trimmed": " <v0.1 ",
+    "leading-v-less-than-unstable/04-major-minor-untrimmed": " <v0.1 ",
+    "leading-v-less-than-unstable/05-major-minor-patch-trimmed": "<v0.1.2",
+    "leading-v-less-than-unstable/06-major-minor-patch-untrimmed": " <v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-less-than-or-equal-stable/01-major-trimmed": "<=1",
+        "leading-v-less-than-or-equal-stable/02-major-untrimmed": "<=1",
+        "leading-v-less-than-or-equal-stable/03-major-minor-trimmed": "<=1.2",
+        "leading-v-less-than-or-equal-stable/04-major-minor-untrimmed": "<=1.2",
+        "leading-v-less-than-or-equal-stable/05-major-minor-patch-trimmed": "<=1.2.3",
+        "leading-v-less-than-or-equal-stable/06-major-minor-patch-untrimmed": "<=1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-less-than-or-equal-stable/01-major-trimmed": "<=v1",
+    "leading-v-less-than-or-equal-stable/02-major-untrimmed": " <=v1 ",
+    "leading-v-less-than-or-equal-stable/03-major-minor-trimmed": " <=v1.2 ",
+    "leading-v-less-than-or-equal-stable/04-major-minor-untrimmed": " <=v1.2 ",
+    "leading-v-less-than-or-equal-stable/05-major-minor-patch-trimmed": "<=v1.2.3",
+    "leading-v-less-than-or-equal-stable/06-major-minor-patch-untrimmed": " <=v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-less-than-or-equal-unstable/01-major-trimmed": "<=0",
+        "leading-v-less-than-or-equal-unstable/02-major-untrimmed": "<=0",
+        "leading-v-less-than-or-equal-unstable/03-major-minor-trimmed": "<=0.1",
+        "leading-v-less-than-or-equal-unstable/04-major-minor-untrimmed": "<=0.1",
+        "leading-v-less-than-or-equal-unstable/05-major-minor-patch-trimmed": "<=0.1.2",
+        "leading-v-less-than-or-equal-unstable/06-major-minor-patch-untrimmed": "<=0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/LessThanOrEqual/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-less-than-or-equal-unstable/01-major-trimmed": "<=v0",
+    "leading-v-less-than-or-equal-unstable/02-major-untrimmed": " <=v0 ",
+    "leading-v-less-than-or-equal-unstable/03-major-minor-trimmed": " <=v0.1 ",
+    "leading-v-less-than-or-equal-unstable/04-major-minor-untrimmed": " <=v0.1 ",
+    "leading-v-less-than-or-equal-unstable/05-major-minor-patch-trimmed": "<=v0.1.2",
+    "leading-v-less-than-or-equal-unstable/06-major-minor-patch-untrimmed": " <=v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-not-equal-to-stable/01-major-trimmed": "!=1",
+        "leading-v-not-equal-to-stable/02-major-untrimmed": "!=1",
+        "leading-v-not-equal-to-stable/03-major-minor-trimmed": "!=1.2",
+        "leading-v-not-equal-to-stable/04-major-minor-untrimmed": "!=1.2",
+        "leading-v-not-equal-to-stable/05-major-minor-patch-trimmed": "!=1.2.3",
+        "leading-v-not-equal-to-stable/06-major-minor-patch-untrimmed": "!=1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-not-equal-to-stable/01-major-trimmed": "!=v1",
+    "leading-v-not-equal-to-stable/02-major-untrimmed": " !=v1 ",
+    "leading-v-not-equal-to-stable/03-major-minor-trimmed": "!=v1.2",
+    "leading-v-not-equal-to-stable/04-major-minor-untrimmed": " !=v1.2 ",
+    "leading-v-not-equal-to-stable/05-major-minor-patch-trimmed": "!=v1.2.3",
+    "leading-v-not-equal-to-stable/06-major-minor-patch-untrimmed": " !=v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-not-equal-to-unstable/01-major-trimmed": "!=0",
+        "leading-v-not-equal-to-unstable/02-major-untrimmed": "!=0",
+        "leading-v-not-equal-to-unstable/03-major-minor-trimmed": "!=0.1",
+        "leading-v-not-equal-to-unstable/04-major-minor-untrimmed": "!=0.1",
+        "leading-v-not-equal-to-unstable/05-major-minor-patch-trimmed": "!=0.1.2",
+        "leading-v-not-equal-to-unstable/06-major-minor-patch-untrimmed": "!=0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/NotEqualTo/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#version-range",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-not-equal-to-unstable/01-major-trimmed": "!=v0",
+    "leading-v-not-equal-to-unstable/02-major-untrimmed": " !=v0 ",
+    "leading-v-not-equal-to-unstable/03-major-minor-trimmed": "!=v0.1",
+    "leading-v-not-equal-to-unstable/04-major-minor-untrimmed": " !=v0.1 ",
+    "leading-v-not-equal-to-unstable/05-major-minor-patch-trimmed": "!=v0.1.2",
+    "leading-v-not-equal-to-unstable/06-major-minor-patch-untrimmed": " !=v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Stable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#tilde-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-tilde-stable/01-major-trimmed": "^1",
+        "leading-v-tilde-stable/02-major-untrimmed": "^1",
+        "leading-v-tilde-stable/03-major-minor-trimmed": "^1.2",
+        "leading-v-tilde-stable/04-major-minor-untrimmed": "^1.2",
+        "leading-v-tilde-stable/05-major-minor-patch-trimmed": "~1.2.3",
+        "leading-v-tilde-stable/06-major-minor-patch-untrimmed": "~1.2.3"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Stable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#tilde-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-tilde-stable/01-major-trimmed": "~v1",
+    "leading-v-tilde-stable/02-major-untrimmed": " ~v1 ",
+    "leading-v-tilde-stable/03-major-minor-trimmed": " ~v1.2 ",
+    "leading-v-tilde-stable/04-major-minor-untrimmed": " ~v1.2 ",
+    "leading-v-tilde-stable/05-major-minor-patch-trimmed": "~v1.2.3",
+    "leading-v-tilde-stable/06-major-minor-patch-untrimmed": " ~v1.2.3 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Unstable/normalized.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#tilde-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-tilde-unstable/01-major-trimmed": "^0",
+        "leading-v-tilde-unstable/02-major-untrimmed": "^0",
+        "leading-v-tilde-unstable/03-major-minor-trimmed": "^0.1",
+        "leading-v-tilde-unstable/04-major-minor-untrimmed": "^0.1",
+        "leading-v-tilde-unstable/05-major-minor-patch-trimmed": "~0.1.2",
+        "leading-v-tilde-unstable/06-major-minor-patch-untrimmed": "~0.1.2"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Unstable/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#tilde-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-tilde-unstable/01-major-trimmed": "~v0",
+    "leading-v-tilde-unstable/02-major-untrimmed": " ~v0 ",
+    "leading-v-tilde-unstable/03-major-minor-trimmed": " ~v0.1 ",
+    "leading-v-tilde-unstable/04-major-minor-untrimmed": " ~v0.1 ",
+    "leading-v-tilde-unstable/05-major-minor-patch-trimmed": "~v0.1.2",
+    "leading-v-tilde-unstable/06-major-minor-patch-untrimmed": " ~v0.1.2 "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Any/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Any/normalized.json
@@ -1,0 +1,7 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-wildcard-any/01-trimmed": "*",
+        "leading-v-wildcard-any/02-untrimmed": "*"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Any/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Any/original.json
@@ -1,0 +1,7 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-wildcard-any/01-trimmed": "*",
+    "leading-v-wildcard-any/02-untrimmed": " * "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Stable/normalized.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-wildcard-stable/01-major-minor-trimmed": "^1.0",
+        "leading-v-wildcard-stable/02-major-minor-untrimmed": "^1.0",
+        "leading-v-wildcard-stable/03-major-minor-patch-trimmed": "~1.2.0",
+        "leading-v-wildcard-stable/04-major-minor-patch-untrimmed": "~1.2.0"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Stable/original.json
@@ -1,0 +1,9 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-wildcard-stable/01-major-minor-trimmed": "v1.*",
+    "leading-v-wildcard-stable/02-major-minor-untrimmed": " v1.* ",
+    "leading-v-wildcard-stable/03-major-minor-patch-trimmed": "v1.2.*",
+    "leading-v-wildcard-stable/04-major-minor-patch-untrimmed": " v1.2.* "
+  }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Unstable/normalized.json
@@ -1,0 +1,9 @@
+{
+    "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
+    "value-contains-packages-and-version-constraints": {
+        "leading-v-wildcard-unstable/01-major-minor-trimmed": "^0.0",
+        "leading-v-wildcard-unstable/02-major-minor-untrimmed": "^0.0",
+        "leading-v-wildcard-unstable/03-major-minor-patch-trimmed": "~0.1.0",
+        "leading-v-wildcard-unstable/04-major-minor-patch-untrimmed": "~0.1.0"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Unstable/original.json
@@ -1,0 +1,9 @@
+{
+  "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
+  "value-contains-packages-and-version-constraints": {
+    "leading-v-wildcard-unstable/01-major-minor-trimmed": "v0.*",
+    "leading-v-wildcard-unstable/02-major-minor-untrimmed": " v0.* ",
+    "leading-v-wildcard-unstable/03-major-minor-patch-trimmed": "v0.1.*",
+    "leading-v-wildcard-unstable/04-major-minor-patch-untrimmed": " v0.1.* "
+  }
+}


### PR DESCRIPTION
This pull request

- removes leading `v` characters from version numbers

Fixes https://github.com/ergebnis/json-normalizer/issues/1003
