### PR TITLE
Fix: Do not attempt to sort item when it disables packagist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`4.4.0...main`][4.4.0...main].
 
+### Fixed
+
+- Stopped sorting an item in `repositories` when it disables packagist ([#1039]), by [@localheinz]
+
 ## [`4.4.0`][4.4.0]
 
 For a full diff see [`4.3.0...4.4.0`][4.3.0...4.4.0].
@@ -664,6 +668,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#992]: https://github.com/ergebnis/json-normalizer/pull/992
 [#1001]: https://github.com/ergebnis/json-normalizer/pull/1001
 [#1027]: https://github.com/ergebnis/json-normalizer/pull/1027
+[#1039]: https://github.com/ergebnis/json-normalizer/pull/1039
 
 [@alexis-saransig-lullabot]: https://github.com/alexis-saransig-lullabot
 [@BackEndTea]: https://github.com/BackEndTea

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -37,11 +37,6 @@
       <code>$value</code>
     </MixedAssignment>
   </file>
-  <file src="src/Vendor/Composer/RepositoriesHashNormalizer.php">
-    <MixedAssignment>
-      <code>$repository</code>
-    </MixedAssignment>
-  </file>
   <file src="src/Vendor/Composer/VersionConstraintNormalizer.php">
     <MixedAssignment>
       <code>$value</code>

--- a/src/Vendor/Composer/RepositoriesHashNormalizer.php
+++ b/src/Vendor/Composer/RepositoriesHashNormalizer.php
@@ -57,6 +57,13 @@ final class RepositoriesHashNormalizer implements Normalizer
         }
 
         foreach ($repositories as &$repository) {
+            /**
+             * @see https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org
+             */
+            if (!\is_array($repository) && !\is_object($repository)) {
+                continue;
+            }
+
             $repository = (array) $repository;
 
             foreach (self::PROPERTIES_WITH_WILDCARDS as $property) {

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsArray/DisablesPackagist/Yes/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsArray/DisablesPackagist/Yes/normalized.json
@@ -1,0 +1,22 @@
+{
+    "name": "ergebnis/json-normalizer",
+    "description": "Provides generic and vendor-specific normalizers for normalizing JSON documents.",
+    "license": "MIT",
+    "type": "library",
+    "keywords": [
+        "json",
+        "normalizer"
+    ],
+    "authors": [
+        {
+            "name": "Andreas Möller",
+            "email": "am@localheinz.com"
+        }
+    ],
+    "homepage": "https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org",
+    "repositories": [
+        {
+            "packagist": false
+        }
+    ]
+}

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsArray/DisablesPackagist/Yes/original.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsArray/DisablesPackagist/Yes/original.json
@@ -1,0 +1,22 @@
+{
+  "name": "ergebnis/json-normalizer",
+  "description": "Provides generic and vendor-specific normalizers for normalizing JSON documents.",
+  "license": "MIT",
+  "type": "library",
+  "keywords": [
+    "json",
+    "normalizer"
+  ],
+  "authors": [
+    {
+      "name": "Andreas Möller",
+      "email": "am@localheinz.com"
+    }
+  ],
+  "homepage": "https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org",
+  "repositories": [
+    {
+      "packagist": false
+    }
+  ]
+}

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsObject/DisablesPackagist/Yes/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsObject/DisablesPackagist/Yes/normalized.json
@@ -1,0 +1,20 @@
+{
+    "name": "ergebnis/json-normalizer",
+    "description": "Provides generic and vendor-specific normalizers for normalizing JSON documents.",
+    "license": "MIT",
+    "type": "library",
+    "keywords": [
+        "json",
+        "normalizer"
+    ],
+    "authors": [
+        {
+            "name": "Andreas Möller",
+            "email": "am@localheinz.com"
+        }
+    ],
+    "homepage": "https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org",
+    "repositories": {
+        "packagist": false
+    }
+}

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsObject/DisablesPackagist/Yes/original.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/Yes/IsObject/DisablesPackagist/Yes/original.json
@@ -1,0 +1,20 @@
+{
+  "name": "ergebnis/json-normalizer",
+  "description": "Provides generic and vendor-specific normalizers for normalizing JSON documents.",
+  "license": "MIT",
+  "type": "library",
+  "keywords": [
+    "json",
+    "normalizer"
+  ],
+  "authors": [
+    {
+      "name": "Andreas Möller",
+      "email": "am@localheinz.com"
+    }
+  ],
+  "homepage": "https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org",
+  "repositories": {
+    "packagist": false
+  }
+}


### PR DESCRIPTION
This pull request

- [x] adds tests for `composer.json` which disables packagist
- [x] skips item when it disables packagist

Related to https://github.com/ergebnis/composer-normalize/issues/124.