### PR TITLE
Replace `x` and `X` wildcards with `*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`4.5.0...main`][4.5.0...main].
 
+### Changed
+
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to replace `x` and `X` wildcards with `*` ([#1052]), by [@fredden]
+
 ## [`4.5.0`][4.5.0]
 
 For a full diff see [`4.4.1...4.5.0`][4.4.1...4.5.0].
@@ -690,6 +694,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#1001]: https://github.com/ergebnis/json-normalizer/pull/1001
 [#1027]: https://github.com/ergebnis/json-normalizer/pull/1027
 [#1039]: https://github.com/ergebnis/json-normalizer/pull/1039
+[#1052]: https://github.com/ergebnis/json-normalizer/pull/1052
 [#1073]: https://github.com/ergebnis/json-normalizer/pull/1073
 [#1074]: https://github.com/ergebnis/json-normalizer/pull/1074
 [#1075]: https://github.com/ergebnis/json-normalizer/pull/1075

--- a/README.md
+++ b/README.md
@@ -614,6 +614,20 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    }
   ```
 
+- use of `x` or `X` for wildcards is replaced with `*`
+
+  ```diff
+   {
+     "require": {
+  -    "foo/bar": "1.x",
+  -    "foo/baz": "2.3.X",
+  -    "foo/qux": "x"
+  +    "foo/bar": "^1.0",
+  +    "foo/baz": "~2.3.0",
+  +    "foo/qux": "*"
+   }
+  ```
+
 ## Changelog
 
 The maintainers of this project record notable changes to this project in a [changelog](CHANGELOG.md).

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -85,6 +85,7 @@ final class VersionConstraintNormalizer implements Normalizer
     {
         $versionConstraint = self::normalizeVersionConstraintSeparators($versionConstraint);
         $versionConstraint = self::removeLeadingVersionPrefix($versionConstraint);
+        $versionConstraint = self::replaceWildcardXWithAsterisk($versionConstraint);
         $versionConstraint = self::replaceWildcardWithTilde($versionConstraint);
         $versionConstraint = self::replaceTildeWithCaret($versionConstraint);
         $versionConstraint = self::removeDuplicateVersionConstraints($versionConstraint);
@@ -119,6 +120,27 @@ final class VersionConstraintNormalizer implements Normalizer
         }, $orConstraints));
     }
 
+    private static function replaceWildcardXWithAsterisk(string $versionConstraint): string
+    {
+        $split = \explode(
+            ' ',
+            $versionConstraint,
+        );
+
+        foreach ($split as &$part) {
+            $part = \preg_replace(
+                '{^[xX]$}',
+                '*',
+                $part,
+            );
+        }
+
+        return \implode(
+            ' ',
+            $split,
+        );
+    }
+
     private static function replaceWildcardWithTilde(string $versionConstraint): string
     {
         $split = \explode(
@@ -128,7 +150,7 @@ final class VersionConstraintNormalizer implements Normalizer
 
         foreach ($split as &$part) {
             $part = \preg_replace(
-                '{^(\d+(?:\.\d+)*)\.\*$}',
+                '{^(\d+(?:\.\d+)*)\.[*xX]$}',
                 '~$1.0',
                 $part,
             );

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -122,6 +122,21 @@ final class VersionConstraintNormalizer implements Normalizer
 
     private static function replaceWildcardXWithAsterisk(string $versionConstraint): string
     {
+        // '1.x.x' -> '1.*'
+        $versionConstraint = self::applyRegularExpressionReplacementToVersionsInTurn(
+            $versionConstraint,
+            '{^(\d+)\.[xX]\.[xX]$}',
+            '$1.*',
+        );
+
+        // '1.x' -> '1.*'
+        $versionConstraint = self::applyRegularExpressionReplacementToVersionsInTurn(
+            $versionConstraint,
+            '{^(\d+)\.[xX]$}',
+            '$1.*',
+        );
+
+        // 'x' -> '*'
         return self::applyRegularExpressionReplacementToVersionsInTurn(
             $versionConstraint,
             '{^[xX]$}',

--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -122,64 +122,28 @@ final class VersionConstraintNormalizer implements Normalizer
 
     private static function replaceWildcardXWithAsterisk(string $versionConstraint): string
     {
-        $split = \explode(
-            ' ',
+        return self::applyRegularExpressionReplacementToVersionsInTurn(
             $versionConstraint,
-        );
-
-        foreach ($split as &$part) {
-            $part = \preg_replace(
-                '{^[xX]$}',
-                '*',
-                $part,
-            );
-        }
-
-        return \implode(
-            ' ',
-            $split,
+            '{^[xX]$}',
+            '*',
         );
     }
 
     private static function replaceWildcardWithTilde(string $versionConstraint): string
     {
-        $split = \explode(
-            ' ',
+        return self::applyRegularExpressionReplacementToVersionsInTurn(
             $versionConstraint,
-        );
-
-        foreach ($split as &$part) {
-            $part = \preg_replace(
-                '{^(\d+(?:\.\d+)*)\.[*xX]$}',
-                '~$1.0',
-                $part,
-            );
-        }
-
-        return \implode(
-            ' ',
-            $split,
+            '{^(\d+(?:\.\d+)*)\.[*xX]$}',
+            '~$1.0',
         );
     }
 
     private static function replaceTildeWithCaret(string $versionConstraint): string
     {
-        $split = \explode(
-            ' ',
+        return self::applyRegularExpressionReplacementToVersionsInTurn(
             $versionConstraint,
-        );
-
-        foreach ($split as &$part) {
-            $part = \preg_replace(
-                '{^~(\d+(?:\.\d+)?)$}',
-                '^$1',
-                $part,
-            );
-        }
-
-        return \implode(
-            ' ',
-            $split,
+            '{^~(\d+(?:\.\d+)?)$}',
+            '^$1',
         );
     }
 
@@ -196,22 +160,10 @@ final class VersionConstraintNormalizer implements Normalizer
 
     private static function removeLeadingVersionPrefix(string $versionConstraint): string
     {
-        $split = \explode(
-            ' ',
+        return self::applyRegularExpressionReplacementToVersionsInTurn(
             $versionConstraint,
-        );
-
-        foreach ($split as &$part) {
-            $part = \preg_replace(
-                '{^(|[!<>]=|[~<>^])v(\d+.*)$}',
-                '$1$2',
-                $part,
-            );
-        }
-
-        return \implode(
-            ' ',
-            $split,
+            '{^(|[!<>]=|[~<>^])v(\d+.*)$}',
+            '$1$2',
         );
     }
 
@@ -346,6 +298,30 @@ final class VersionConstraintNormalizer implements Normalizer
         return \implode(
             ' ',
             $andConstraints,
+        );
+    }
+
+    /**
+     * @param non-empty-string $find
+     */
+    private static function applyRegularExpressionReplacementToVersionsInTurn(string $versionConstraint, string $find, string $replace): string
+    {
+        $split = \explode(
+            ' ',
+            $versionConstraint,
+        );
+
+        foreach ($split as &$part) {
+            $part = \preg_replace(
+                $find,
+                $replace,
+                $part,
+            );
+        }
+
+        return \implode(
+            ' ',
+            $split,
         );
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/normalized.json
@@ -2,6 +2,8 @@
     "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
     "value-contains-packages-and-version-constraints": {
         "version-range-wildcard-any/01-trimmed": "*",
-        "version-range-wildcard-any/02-untrimmed": "*"
+        "version-range-wildcard-any/02-untrimmed": "*",
+        "version-range-wildcard-any/03-lower-x": "*",
+        "version-range-wildcard-any/04-upper-X": "*"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/original.json
@@ -2,6 +2,8 @@
   "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
   "value-contains-packages-and-version-constraints": {
     "version-range-wildcard-any/01-trimmed": "*",
-    "version-range-wildcard-any/02-untrimmed": " * "
+    "version-range-wildcard-any/02-untrimmed": " * ",
+    "version-range-wildcard-any/03-lower-x": "x",
+    "version-range-wildcard-any/04-upper-X": "X"
   }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/normalized.json
@@ -8,6 +8,10 @@
         "version-range-wildcard-stable/05-major-minor-patch-trimmed": "~1.2.0",
         "version-range-wildcard-stable/06-major-minor-patch-untrimmed": "~1.2.0",
         "version-range-wildcard-stable/07-major-minor-patch-lower-x": "~1.2.0",
-        "version-range-wildcard-stable/08-major-minor-patch-upper-X": "~1.2.0"
+        "version-range-wildcard-stable/08-major-minor-patch-upper-X": "~1.2.0",
+        "version-range-wildcard-stable/09-major-minor-patch-lower-x": "^1.0",
+        "version-range-wildcard-stable/10-major-minor-patch-upper-X": "^1.0",
+        "version-range-wildcard-stable/11-major-minor-patch-mixed-xX": "^1.0",
+        "version-range-wildcard-stable/12-major-minor-patch-mixed-Xx": "^1.0"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/normalized.json
@@ -3,7 +3,11 @@
     "value-contains-packages-and-version-constraints": {
         "version-range-wildcard-stable/01-major-minor-trimmed": "^1.0",
         "version-range-wildcard-stable/02-major-minor-untrimmed": "^1.0",
-        "version-range-wildcard-stable/03-major-minor-patch-trimmed": "~1.2.0",
-        "version-range-wildcard-stable/04-major-minor-patch-untrimmed": "~1.2.0"
+        "version-range-wildcard-stable/03-major-minor-lower-x": "^1.0",
+        "version-range-wildcard-stable/04-major-minor-upper-X": "^1.0",
+        "version-range-wildcard-stable/05-major-minor-patch-trimmed": "~1.2.0",
+        "version-range-wildcard-stable/06-major-minor-patch-untrimmed": "~1.2.0",
+        "version-range-wildcard-stable/07-major-minor-patch-lower-x": "~1.2.0",
+        "version-range-wildcard-stable/08-major-minor-patch-upper-X": "~1.2.0"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/original.json
@@ -3,7 +3,11 @@
   "value-contains-packages-and-version-constraints": {
     "version-range-wildcard-stable/01-major-minor-trimmed": "1.*",
     "version-range-wildcard-stable/02-major-minor-untrimmed": " 1.* ",
-    "version-range-wildcard-stable/03-major-minor-patch-trimmed": "1.2.*",
-    "version-range-wildcard-stable/04-major-minor-patch-untrimmed": " 1.2.* "
+    "version-range-wildcard-stable/03-major-minor-lower-x": "1.x",
+    "version-range-wildcard-stable/04-major-minor-upper-X": "1.X",
+    "version-range-wildcard-stable/05-major-minor-patch-trimmed": "1.2.*",
+    "version-range-wildcard-stable/06-major-minor-patch-untrimmed": " 1.2.* ",
+    "version-range-wildcard-stable/07-major-minor-patch-lower-x": "1.2.x",
+    "version-range-wildcard-stable/08-major-minor-patch-upper-X": "1.2.X"
   }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Stable/original.json
@@ -8,6 +8,10 @@
     "version-range-wildcard-stable/05-major-minor-patch-trimmed": "1.2.*",
     "version-range-wildcard-stable/06-major-minor-patch-untrimmed": " 1.2.* ",
     "version-range-wildcard-stable/07-major-minor-patch-lower-x": "1.2.x",
-    "version-range-wildcard-stable/08-major-minor-patch-upper-X": "1.2.X"
+    "version-range-wildcard-stable/08-major-minor-patch-upper-X": "1.2.X",
+    "version-range-wildcard-stable/09-major-minor-patch-lower-x": "1.x.x",
+    "version-range-wildcard-stable/10-major-minor-patch-upper-X": "1.X.X",
+    "version-range-wildcard-stable/11-major-minor-patch-mixed-xX": "1.x.X",
+    "version-range-wildcard-stable/12-major-minor-patch-mixed-Xx": "1.X.x"
   }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/normalized.json
@@ -8,6 +8,10 @@
         "version-range-wildcard-unstable/05-major-minor-patch-trimmed": "~0.1.0",
         "version-range-wildcard-unstable/06-major-minor-patch-untrimmed": "~0.1.0",
         "version-range-wildcard-unstable/07-major-minor-patch-lower-x": "~0.1.0",
-        "version-range-wildcard-unstable/08-major-minor-patch-upper-X": "~0.1.0"
+        "version-range-wildcard-unstable/08-major-minor-patch-upper-X": "~0.1.0",
+        "version-range-wildcard-unstable/09-major-minor-patch-lower-x": "^0.0",
+        "version-range-wildcard-unstable/10-major-minor-patch-upper-X": "^0.0",
+        "version-range-wildcard-unstable/11-major-minor-patch-mixed-xX": "^0.0",
+        "version-range-wildcard-unstable/12-major-minor-patch-mixed-Xx": "^0.0"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/normalized.json
@@ -3,7 +3,11 @@
     "value-contains-packages-and-version-constraints": {
         "version-range-wildcard-unstable/01-major-minor-trimmed": "^0.0",
         "version-range-wildcard-unstable/02-major-minor-untrimmed": "^0.0",
-        "version-range-wildcard-unstable/03-major-minor-patch-trimmed": "~0.1.0",
-        "version-range-wildcard-unstable/04-major-minor-patch-untrimmed": "~0.1.0"
+        "version-range-wildcard-unstable/03-major-minor-lower-x": "^0.0",
+        "version-range-wildcard-unstable/04-major-minor-upper-X": "^0.0",
+        "version-range-wildcard-unstable/05-major-minor-patch-trimmed": "~0.1.0",
+        "version-range-wildcard-unstable/06-major-minor-patch-untrimmed": "~0.1.0",
+        "version-range-wildcard-unstable/07-major-minor-patch-lower-x": "~0.1.0",
+        "version-range-wildcard-unstable/08-major-minor-patch-upper-X": "~0.1.0"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/original.json
@@ -8,6 +8,10 @@
     "version-range-wildcard-unstable/05-major-minor-patch-trimmed": "0.1.*",
     "version-range-wildcard-unstable/06-major-minor-patch-untrimmed": " 0.1.* ",
     "version-range-wildcard-unstable/07-major-minor-patch-lower-x": "0.1.x",
-    "version-range-wildcard-unstable/08-major-minor-patch-upper-X": "0.1.X"
+    "version-range-wildcard-unstable/08-major-minor-patch-upper-X": "0.1.X",
+    "version-range-wildcard-unstable/09-major-minor-patch-lower-x": "0.x.x",
+    "version-range-wildcard-unstable/10-major-minor-patch-upper-X": "0.X.X",
+    "version-range-wildcard-unstable/11-major-minor-patch-mixed-xX": "0.x.X",
+    "version-range-wildcard-unstable/12-major-minor-patch-mixed-Xx": "0.X.x"
   }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/original.json
@@ -3,7 +3,11 @@
   "value-contains-packages-and-version-constraints": {
     "version-range-wildcard-unstable/01-major-minor-trimmed": "0.*",
     "version-range-wildcard-unstable/02-major-minor-untrimmed": " 0.* ",
-    "version-range-wildcard-unstable/03-major-minor-patch-trimmed": "0.1.*",
-    "version-range-wildcard-unstable/04-major-minor-patch-untrimmed": " 0.1.* "
+    "version-range-wildcard-unstable/03-major-minor-lower-x": "0.x",
+    "version-range-wildcard-unstable/04-major-minor-upper-X": "0.X",
+    "version-range-wildcard-unstable/05-major-minor-patch-trimmed": "0.1.*",
+    "version-range-wildcard-unstable/06-major-minor-patch-untrimmed": " 0.1.* ",
+    "version-range-wildcard-unstable/07-major-minor-patch-lower-x": "0.1.x",
+    "version-range-wildcard-unstable/08-major-minor-patch-upper-X": "0.1.X"
   }
 }


### PR DESCRIPTION
This pull request was inspired by https://twitter.com/localheinz/status/1741201630681272557. While I expect a major change to the test-suite here with the incorporation of new packages in the "ergebnis" namespace, normalising `x` and `X` to `*` seems like a sensible addition to composer-normalize.

- Replace `x` and `X` wildcards with `*`
- Reduce some duplicate code with the introduction of a new private method