### PR TITLE
Prune empty sections in `composer.json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`4.8.0...main`][4.8.0...main].
 
+### Changed
+
+- Adjusted `SchemaNormalizer` to allow pruning empty sections when the schema declares them as not required ([#1053]), by [@fredden]
+
 ## [`4.8.0`][4.8.0]
 
 For a full diff see [`4.7.0...4.8.0`][4.7.0...4.8.0].
@@ -722,6 +726,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#1027]: https://github.com/ergebnis/json-normalizer/pull/1027
 [#1039]: https://github.com/ergebnis/json-normalizer/pull/1039
 [#1052]: https://github.com/ergebnis/json-normalizer/pull/1052
+[#1053]: https://github.com/ergebnis/json-normalizer/pull/1053
 [#1073]: https://github.com/ergebnis/json-normalizer/pull/1073
 [#1074]: https://github.com/ergebnis/json-normalizer/pull/1074
 [#1075]: https://github.com/ergebnis/json-normalizer/pull/1075

--- a/README.md
+++ b/README.md
@@ -626,6 +626,19 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    }
   ```
 
+- empty sections (which are defined as optional in the schema) are automatically removed
+
+  ```diff
+   {
+      "require": {
+          "foo/bar": "^2.3.4"
+      }
+  -   "config": {
+  -       "preferred-install": {}
+  -   }
+   }
+  ```
+
 ## Changelog
 
 The maintainers of this project record notable changes to this project in a [changelog](CHANGELOG.md).

--- a/src/SchemaNormalizer.php
+++ b/src/SchemaNormalizer.php
@@ -28,17 +28,20 @@ final class SchemaNormalizer implements Normalizer
     private SchemaValidator\SchemaValidator $schemaValidator;
     private SchemaStorage $schemaStorage;
     private string $schemaUri;
+    private bool $pruneEmpty;
 
     public function __construct(
         string $schemaUri,
         SchemaStorage $schemaStorage,
         SchemaValidator\SchemaValidator $schemaValidator,
-        Pointer\Specification $specificationForPointerToDataThatShouldNotBeSorted
+        Pointer\Specification $specificationForPointerToDataThatShouldNotBeSorted,
+        bool $pruneEmpty = false
     ) {
         $this->schemaUri = $schemaUri;
         $this->schemaStorage = $schemaStorage;
         $this->schemaValidator = $schemaValidator;
         $this->specificationForPointerToDataThatShouldNotBeSorted = $specificationForPointerToDataThatShouldNotBeSorted;
+        $this->pruneEmpty = $pruneEmpty;
     }
 
     public function normalize(Json $json): Json
@@ -223,6 +226,14 @@ final class SchemaNormalizer implements Normalizer
                     $pointerToData->append(Pointer\ReferenceToken::fromString($name)),
                 );
 
+                if (
+                    $this->pruneEmpty
+                    && [] === (array) $normalized->{$name}
+                    && self::isKeyOptionalInSchema($schema, $name)
+                ) {
+                    unset($normalized->{$name});
+                }
+
                 unset($data->{$name});
             }
         }
@@ -326,5 +337,20 @@ final class SchemaNormalizer implements Normalizer
         }
 
         return $schema;
+    }
+
+    private static function isKeyOptionalInSchema(
+        object $schema,
+        string $name
+    ): bool {
+        if (
+            \property_exists($schema, 'required')
+            && \is_array($schema->required)
+            && \in_array($name, $schema->required, true)
+        ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Vendor/Composer/ComposerJsonNormalizer.php
+++ b/src/Vendor/Composer/ComposerJsonNormalizer.php
@@ -89,6 +89,7 @@ final class ComposerJsonNormalizer implements Normalizer\Normalizer
                      */
                     Pointer\Specification::equals(Pointer\JsonPointer::fromJsonString('/scripts/auto-scripts')),
                 ),
+                true,
             ),
             new BinNormalizer(),
             new ConfigHashNormalizer(),

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Bin/IsArray/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Bin/IsArray/HasEntries/No/normalized.json
@@ -13,6 +13,5 @@
             "email": "am@localheinz.com"
         }
     ],
-    "homepage": "https://getcomposer.org/doc/04-schema.md#bin",
-    "bin": []
+    "homepage": "https://getcomposer.org/doc/04-schema.md#bin"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/No/normalized.json
@@ -13,6 +13,5 @@
             "email": "am@localheinz.com"
         }
     ],
-    "homepage": "https://getcomposer.org/doc/06-config.md",
-    "config": {}
+    "homepage": "https://getcomposer.org/doc/06-config.md"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/HasProperty/AllowPlugins/IsObject/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/HasProperty/AllowPlugins/IsObject/HasEntries/No/normalized.json
@@ -13,8 +13,5 @@
             "email": "am@localheinz.com"
         }
     ],
-    "homepage": "https://getcomposer.org/doc/06-config.md#allow-plugins",
-    "config": {
-        "allow-plugins": {}
-    }
+    "homepage": "https://getcomposer.org/doc/06-config.md#allow-plugins"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/HasProperty/PreferredInstall/IsObject/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/HasProperty/PreferredInstall/IsObject/HasEntries/No/normalized.json
@@ -13,8 +13,5 @@
             "email": "am@localheinz.com"
         }
     ],
-    "homepage": "https://getcomposer.org/doc/06-config.md#preferred-install",
-    "config": {
-        "preferred-install": {}
-    }
+    "homepage": "https://getcomposer.org/doc/06-config.md#preferred-install"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/No/normalized.json
@@ -15,7 +15,6 @@
     ],
     "homepage": "https://getcomposer.org/doc/06-config.md",
     "config": {
-        "allow-plugins": {},
         "platform": {
             "php": "8.0.25"
         },

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Config/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
@@ -15,7 +15,6 @@
     ],
     "homepage": "https://getcomposer.org/doc/06-config.md",
     "config": {
-        "allow-plugins": {},
         "platform": {
             "php": "8.0.25"
         },

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Extra/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Extra/HasEntries/No/normalized.json
@@ -13,6 +13,5 @@
             "email": "am@localheinz.com"
         }
     ],
-    "homepage": "https://getcomposer.org/doc/04-schema.md#extra",
-    "extra": {}
+    "homepage": "https://getcomposer.org/doc/04-schema.md#extra"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Repositories/HasEntries/No/normalized.json
@@ -13,6 +13,5 @@
             "email": "am@localheinz.com"
         }
     ],
-    "homepage": "https://getcomposer.org/doc/04-schema.md#repositories",
-    "repositories": []
+    "homepage": "https://getcomposer.org/doc/04-schema.md#repositories"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/RequireAndRequireDev/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/RequireAndRequireDev/normalized.json
@@ -1,6 +1,5 @@
 {
     "description": "This test exists to cover certain mutants from infection/infection",
-    "require": {},
     "require-dev": {
         "ergebnis/overlapping-version-constraints-1": "^1.0 || 3.4.5",
         "ergebnis/overlapping-version-constraints-2": "^1.0 || ^2.0",

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Scripts/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Scripts/HasEntries/No/normalized.json
@@ -13,6 +13,5 @@
             "email": "am@localheinz.com"
         }
     ],
-    "homepage": "https://getcomposer.org/doc/04-schema.md#scripts",
-    "scripts": {}
+    "homepage": "https://getcomposer.org/doc/04-schema.md#scripts"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/No/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/No/normalized.json
@@ -1,4 +1,3 @@
 {
-    "homepage": "https://getcomposer.org/doc/04-schema.md#suggest",
-    "suggest": {}
+    "homepage": "https://getcomposer.org/doc/04-schema.md#suggest"
 }

--- a/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
+++ b/test/Fixture/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/Suggest/HasEntries/Yes/IsSortedByKey/Yes/normalized.json
@@ -1,6 +1,5 @@
 {
     "homepage": "https://getcomposer.org/doc/04-schema.md#suggest",
-    "require": {},
     "suggest": {
         "php": "Nothing works without it",
         "hhvm": "Okay",

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/No/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/No/normalized.json
@@ -1,3 +1,1 @@
-{
-    "value-contains-packages-and-version-constraints": {}
-}
+{}


### PR DESCRIPTION
This pull request removes empty sections from `composer.json` when they are defined as optional (or more specifically, not specified as required) according to the schema.

I have hidden this feature behind an optional constructor property, so that other users of this package can decide if they also want to have empty-and-optional elements removed during normalisation.

The removal happens after normalisation so we can process nesting properly.

I chose to *not remove* empty elements which are not defined in the schema.

Related to https://github.com/composer/composer/issues/7691