### PR TITLE
Normalise extension requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`4.8.0...main`][4.8.0...main].
 
 - Adjusted `SchemaNormalizer` to allow pruning empty sections when the schema declares them as not required ([#1053]), by [@fredden]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to correctly use `dev-` prefixes and `-dev` suffixes ([#1055]), by [@fredden]
+- Adjusted `Vendor\Composer\VersionConstraintNormalizer` to normalize and (if necessary) combine version constraints refering to extensions ([#1185]), by [@fredden]
 - Adjusted `Vendor\Composer\VersionConstraintNormalizer` to normalize version constraints that are combined with `*` to `*` ([#1186]), by [@fredden]
 
 ## [`4.8.0`][4.8.0]
@@ -737,6 +738,7 @@ For a full diff see [`5d8b3e2...0.1.0`][5d8b3e2...0.1.0].
 [#1077]: https://github.com/ergebnis/json-normalizer/pull/1077
 [#1079]: https://github.com/ergebnis/json-normalizer/pull/1079
 [#1171]: https://github.com/ergebnis/json-normalizer/pull/1171
+[#1185]: https://github.com/ergebnis/json-normalizer/pull/1185
 [#1186]: https://github.com/ergebnis/json-normalizer/pull/1186
 [#1195]: https://github.com/ergebnis/json-normalizer/pull/1195
 [#1198]: https://github.com/ergebnis/json-normalizer/pull/1198

--- a/src/Vendor/Composer/PackageHashNormalizer.php
+++ b/src/Vendor/Composer/PackageHashNormalizer.php
@@ -57,6 +57,7 @@ final class PackageHashNormalizer implements Normalizer
                 continue;
             }
 
+            $packages = self::mergeDuplicateExtensions($packages);
             $decoded->{$name} = self::sortPackages($packages);
         }
 
@@ -111,6 +112,40 @@ final class PackageHashNormalizer implements Normalizer
                 $prefix($b),
             );
         });
+
+        return $packages;
+    }
+
+    /**
+     * This code is adopted from composer/composer (originally licensed under MIT by Nils Adermann <naderman@naderman.de>
+     * and Jordi Boggiano <j.boggiano@seld.be>).
+     *
+     * @see https://github.com/composer/composer/blob/2.8.1/src/Composer/Repository/PlatformRepository.php#L682
+     *
+     * @param array<string, string> $packages
+     *
+     * @return array<string, string>
+     */
+    private static function mergeDuplicateExtensions($packages): array
+    {
+        foreach ($packages as $name => $value) {
+            if (!isset($name[4]) || \strtolower(\substr($name, 0, 4)) !== 'ext-') {
+                continue;
+            }
+
+            $newName = \str_replace(' ', '-', \strtolower($name));
+
+            if ($name === $newName) {
+                continue;
+            }
+
+            if (isset($packages[$newName])) {
+                $value .= '||' . $packages[$newName];
+            }
+
+            $packages[$newName] = $value;
+            unset($packages[$name]);
+        }
 
         return $packages;
     }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Extension/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Extension/normalized.json
@@ -1,0 +1,6 @@
+{
+    "homepage": "https://github.com/ergebnis/composer-normalize/issues/1388",
+    "value-contains-packages-and-version-constraints": {
+        "ext-extension-name": "1 || 2 || 3 || 4 || 5 || 6"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Extension/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/Extension/original.json
@@ -1,0 +1,11 @@
+{
+  "homepage": "https://github.com/ergebnis/composer-normalize/issues/1388",
+  "value-contains-packages-and-version-constraints": {
+    "ext-extension name": "1",
+    "ext-Extension Name": "2",
+    "ext-EXTENSION NAME": "3",
+    "ext-extension-name": "4",
+    "ext-Extension-Name": "5",
+    "ext-EXTENSION-NAME": "6"
+  }
+}


### PR DESCRIPTION
This pull request adds normalisation for `ext-*` requirements, to match what Composer does internally. I chose to join any collisions with an 'or' separator.

Related to https://github.com/ergebnis/composer-normalize/issues/1388