### PR TITLE
Handle case when lone wildcard is ORed with other constraints

### DIFF
--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -234,6 +234,10 @@ final class VersionConstraintNormalizer implements Normalizer
                 continue;
             }
 
+            if ('*' === $a) {
+                return $a;
+            }
+
             if (1 !== \preg_match($regex, $a)) {
                 continue;
             }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/normalized.json
@@ -4,6 +4,7 @@
         "version-range-wildcard-any/01-trimmed": "*",
         "version-range-wildcard-any/02-untrimmed": "*",
         "version-range-wildcard-any/03-lower-x": "*",
-        "version-range-wildcard-any/04-upper-X": "*"
+        "version-range-wildcard-any/04-upper-X": "*",
+        "version-range-wildcard-any/05-overlap": "*"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Any/original.json
@@ -4,6 +4,7 @@
     "version-range-wildcard-any/01-trimmed": "*",
     "version-range-wildcard-any/02-untrimmed": " * ",
     "version-range-wildcard-any/03-lower-x": "x",
-    "version-range-wildcard-any/04-upper-X": "X"
+    "version-range-wildcard-any/04-upper-X": "X",
+    "version-range-wildcard-any/05-overlap": "1.2.3 || 4.5.* || 6.* || *"
   }
 }


### PR DESCRIPTION
While working on another feature, I noticed that a constraint like `* || 1.2.3` wasn't being normalised to just `*` as expected. This pull request fixes this oversight.

While working on *this* change, I noticed that a constraint like `*, 1.2.3` isn't normalised to `1.2.3`. Let's deal with this in a separate step. (It's late here and I'm tired.)