### PR TITLE
Treat stability modifiers separately to versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,18 @@ sections, the `Vendor\Composer\VersionConstraintNormalizer` will ensure that
    }
   ```
 
+- stability modifiers are listed first to show they apply to the package and not a particular version constraint
+
+  ```diff
+   {
+     "require": {
+  -    "foo/bar": "^1.0@dev",
+  -    "foo/baz": "^1.0 || ^2.3@RC || ^4.5"
+  +    "foo/bar": "@dev ^1.0",
+  +    "foo/baz": "@RC ^1.0 || ^2.3 || ^4.5"
+   }
+  ```
+
 - empty sections (which are defined as optional in the schema) are automatically removed
 
   ```diff

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/StabilityModifier/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/StabilityModifier/normalized.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://getcomposer.org/doc/04-schema.md#minimum-stability",
+    "value-contains-packages-and-version-constraints": {
+        "stability/00-dev-caret": "@dev ^1.6",
+        "stability/01-dev-caret-overlap": "@dev ^2.0",
+        "stability/02-alpha-caret": "@alpha ^1.6",
+        "stability/03-alpha-caret-overlap": "@alpha ^2.0",
+        "stability/04-beta-caret": "@beta ^1.6",
+        "stability/05-beta-caret-overlap": "@beta ^2.0",
+        "stability/06-RC-caret": "@RC ^1.6",
+        "stability/07-RC-caret-overlap": "@RC ^2.0",
+        "stability/08-stable-caret": "@stable ^1.6",
+        "stability/09-stable-caret-overlap": "@stable ^2.0",
+        "stability/10-dev-caret-dev-caret": "@dev ^3.4",
+        "stability/11-RC-caret-beta-caret": "@beta ^4.0 || ^5.0",
+        "stability/12-alpha-alone": "@alpha"
+    }
+}

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/StabilityModifier/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/StabilityModifier/original.json
@@ -1,0 +1,18 @@
+{
+  "homepage": "https://getcomposer.org/doc/04-schema.md#minimum-stability",
+  "value-contains-packages-and-version-constraints": {
+    "stability/00-dev-caret": "^1.6@dev",
+    "stability/01-dev-caret-overlap": "^2.0 || ^2.1@dev",
+    "stability/02-alpha-caret": "^1.6@alpha",
+    "stability/03-alpha-caret-overlap": "^2.0 || ^2.1@alpha",
+    "stability/04-beta-caret": "^1.6@beta",
+    "stability/05-beta-caret-overlap": "^2.0 || ^2.1@beta",
+    "stability/06-RC-caret": "^1.6@RC",
+    "stability/07-RC-caret-overlap": "^2.0 || ^2.1@RC",
+    "stability/08-stable-caret": "^1.6@stable",
+    "stability/09-stable-caret-overlap": "^2.0 || ^2.1@stable",
+    "stability/10-dev-caret-dev-caret": "^3.4@dev || ^3.5@dev",
+    "stability/11-RC-caret-beta-caret": "^4.0@RC || ^5.0@beta",
+    "stability/12-alpha-alone": "@alpha"
+  }
+}


### PR DESCRIPTION
This pull request will update the normalisation rules to include moving stability modifiers for Composer to the beginning of the list of version constraints.

Fixes https://github.com/ergebnis/composer-normalize/issues/1548
