### PR TITLE
Treat unstable versions with tilde specially

### DIFF
--- a/src/Vendor/Composer/VersionConstraintNormalizer.php
+++ b/src/Vendor/Composer/VersionConstraintNormalizer.php
@@ -156,11 +156,31 @@ final class VersionConstraintNormalizer implements Normalizer
 
     private static function replaceTildeWithCaret(string $versionConstraint): string
     {
-        return self::applyRegularExpressionReplacementToVersionsInTurn(
+        // Remove any leading zeros from tilde version numbers. This simplifies the following steps.
+        $versionConstraint = self::applyRegularExpressionReplacementToVersionsInTurn(
             $versionConstraint,
-            '{^~(\d+(?:\.\d+)?)$}',
+            '{^~0*(\d)}',
+            '~$1',
+        );
+
+        // ~0 and ^0 are equivalent.
+        // ~1 and ^1 are equivalent.
+        $versionConstraint = self::applyRegularExpressionReplacementToVersionsInTurn(
+            $versionConstraint,
+            '{^~(\d+)$}',
             '^$1',
         );
+
+        // ~0.1 and ^0.1 are NOT equivalent.
+        // ~1.1 and ^1.1 are equivalent.
+        return self::applyRegularExpressionReplacementToVersionsInTurn(
+            $versionConstraint,
+            '{^~([1-9]\d*\.\d+)$}',
+            '^$1',
+        );
+
+        // ~0.1.2 and ^0.1.2 are equivalent. HOWEVER, the former is more clear regarding behaviour.
+        // ~1.2.3 and ^1.2.3 are NOT equivalent.
     }
 
     private static function removeDuplicateVersionConstraints(string $versionConstraint): string

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Tilde/Unstable/normalized.json
@@ -3,8 +3,8 @@
     "value-contains-packages-and-version-constraints": {
         "leading-v-tilde-unstable/01-major-trimmed": "^0",
         "leading-v-tilde-unstable/02-major-untrimmed": "^0",
-        "leading-v-tilde-unstable/03-major-minor-trimmed": "^0.1",
-        "leading-v-tilde-unstable/04-major-minor-untrimmed": "^0.1",
+        "leading-v-tilde-unstable/03-major-minor-trimmed": "~0.1",
+        "leading-v-tilde-unstable/04-major-minor-untrimmed": "~0.1",
         "leading-v-tilde-unstable/05-major-minor-patch-trimmed": "~0.1.2",
         "leading-v-tilde-unstable/06-major-minor-patch-untrimmed": "~0.1.2"
     }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/LeadingV/Wildcard/Unstable/normalized.json
@@ -1,8 +1,8 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
     "value-contains-packages-and-version-constraints": {
-        "leading-v-wildcard-unstable/01-major-minor-trimmed": "^0.0",
-        "leading-v-wildcard-unstable/02-major-minor-untrimmed": "^0.0",
+        "leading-v-wildcard-unstable/01-major-minor-trimmed": "~0.0",
+        "leading-v-wildcard-unstable/02-major-minor-untrimmed": "~0.0",
         "leading-v-wildcard-unstable/03-major-minor-patch-trimmed": "~0.1.0",
         "leading-v-wildcard-unstable/04-major-minor-patch-untrimmed": "~0.1.0"
     }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Stable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Stable/normalized.json
@@ -6,6 +6,9 @@
         "version-range-tilde-stable/03-major-minor-trimmed": "^1.2",
         "version-range-tilde-stable/04-major-minor-untrimmed": "^1.2",
         "version-range-tilde-stable/05-major-minor-patch-trimmed": "~1.2.3",
-        "version-range-tilde-stable/06-major-minor-patch-untrimmed": "~1.2.3"
+        "version-range-tilde-stable/06-major-minor-patch-untrimmed": "~1.2.3",
+        "version-range-tilde-stable/07-leading-zero-major": "^7",
+        "version-range-tilde-stable/08-leading-zero-minor": "^5.2",
+        "version-range-tilde-stable/09-leading-zero-patch": "~3.2.1"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Stable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Stable/original.json
@@ -6,6 +6,9 @@
     "version-range-tilde-stable/03-major-minor-trimmed": " ~1.2 ",
     "version-range-tilde-stable/04-major-minor-untrimmed": " ~1.2 ",
     "version-range-tilde-stable/05-major-minor-patch-trimmed": "~1.2.3",
-    "version-range-tilde-stable/06-major-minor-patch-untrimmed": " ~1.2.3 "
+    "version-range-tilde-stable/06-major-minor-patch-untrimmed": " ~1.2.3 ",
+    "version-range-tilde-stable/07-leading-zero-major": "~007",
+    "version-range-tilde-stable/08-leading-zero-minor": "~05.2",
+    "version-range-tilde-stable/09-leading-zero-patch": "~03.2.1"
   }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Unstable/normalized.json
@@ -3,9 +3,12 @@
     "value-contains-packages-and-version-constraints": {
         "version-range-tilde-unstable/01-major-trimmed": "^0",
         "version-range-tilde-unstable/02-major-untrimmed": "^0",
-        "version-range-tilde-unstable/03-major-minor-trimmed": "^0.1",
-        "version-range-tilde-unstable/04-major-minor-untrimmed": "^0.1",
+        "version-range-tilde-unstable/03-major-minor-trimmed": "~0.1",
+        "version-range-tilde-unstable/04-major-minor-untrimmed": "~0.1",
         "version-range-tilde-unstable/05-major-minor-patch-trimmed": "~0.1.2",
-        "version-range-tilde-unstable/06-major-minor-patch-untrimmed": "~0.1.2"
+        "version-range-tilde-unstable/06-major-minor-patch-untrimmed": "~0.1.2",
+        "version-range-tilde-unstable/07-leading-zero-major": "^0",
+        "version-range-tilde-unstable/08-leading-zero-minor": "~0.1",
+        "version-range-tilde-unstable/09-leading-zero-patch": "~0.1.2"
     }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Unstable/original.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Tilde/Unstable/original.json
@@ -6,6 +6,9 @@
     "version-range-tilde-unstable/03-major-minor-trimmed": " ~0.1 ",
     "version-range-tilde-unstable/04-major-minor-untrimmed": " ~0.1 ",
     "version-range-tilde-unstable/05-major-minor-patch-trimmed": "~0.1.2",
-    "version-range-tilde-unstable/06-major-minor-patch-untrimmed": " ~0.1.2 "
+    "version-range-tilde-unstable/06-major-minor-patch-untrimmed": " ~0.1.2 ",
+    "version-range-tilde-unstable/07-leading-zero-major": "~00",
+    "version-range-tilde-unstable/08-leading-zero-minor": "~00.1",
+    "version-range-tilde-unstable/09-leading-zero-patch": "~00.1.2"
   }
 }

--- a/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/normalized.json
+++ b/test/Template/Vendor/Composer/ComposerJsonNormalizer/NormalizeNormalizesJson/Json/IsObject/HasEntries/Yes/HasProperty/ValueContainsPackagesAndVersionConstraints/HasEntries/Yes/HasNormalizedVersionConstraints/No/VersionRange/Wildcard/Unstable/normalized.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://getcomposer.org/doc/articles/versions.md#wildcard-version-range-",
     "value-contains-packages-and-version-constraints": {
-        "version-range-wildcard-unstable/01-major-minor-trimmed": "^0.0",
-        "version-range-wildcard-unstable/02-major-minor-untrimmed": "^0.0",
-        "version-range-wildcard-unstable/03-major-minor-lower-x": "^0.0",
-        "version-range-wildcard-unstable/04-major-minor-upper-X": "^0.0",
+        "version-range-wildcard-unstable/01-major-minor-trimmed": "~0.0",
+        "version-range-wildcard-unstable/02-major-minor-untrimmed": "~0.0",
+        "version-range-wildcard-unstable/03-major-minor-lower-x": "~0.0",
+        "version-range-wildcard-unstable/04-major-minor-upper-X": "~0.0",
         "version-range-wildcard-unstable/05-major-minor-patch-trimmed": "~0.1.0",
         "version-range-wildcard-unstable/06-major-minor-patch-untrimmed": "~0.1.0",
         "version-range-wildcard-unstable/07-major-minor-patch-lower-x": "~0.1.0",
         "version-range-wildcard-unstable/08-major-minor-patch-upper-X": "~0.1.0",
-        "version-range-wildcard-unstable/09-major-minor-patch-lower-x": "^0.0",
-        "version-range-wildcard-unstable/10-major-minor-patch-upper-X": "^0.0",
-        "version-range-wildcard-unstable/11-major-minor-patch-mixed-xX": "^0.0",
-        "version-range-wildcard-unstable/12-major-minor-patch-mixed-Xx": "^0.0"
+        "version-range-wildcard-unstable/09-major-minor-patch-lower-x": "~0.0",
+        "version-range-wildcard-unstable/10-major-minor-patch-upper-X": "~0.0",
+        "version-range-wildcard-unstable/11-major-minor-patch-mixed-xX": "~0.0",
+        "version-range-wildcard-unstable/12-major-minor-patch-mixed-Xx": "~0.0"
     }
 }


### PR DESCRIPTION
This pull request changes the normalisation rules for [tilde (`~`) version ranges](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-) to cope with unstable / pre-1.0 version numbers.

For example, compare the selected versions on these two URLs:
* https://semver.madewithlove.com/?package=psr%2Fhttp-message&constraint=~0.1
* https://semver.madewithlove.com/?package=psr%2Fhttp-message&constraint=%5E0.1

Fixes https://github.com/ergebnis/composer-normalize/issues/1473
Fixes https://github.com/ergebnis/composer-normalize/issues/1584